### PR TITLE
Added -ExcludeFile parameter to Invoke-BicepBuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /tmp
+.vscode

--- a/Source/Public/Invoke-BicepBuild.ps1
+++ b/Source/Public/Invoke-BicepBuild.ps1
@@ -21,15 +21,27 @@
     Go to module repository https://github.com/StefanIvemo/BicepPowerShell for detailed info, reporting issues and to submit contributions.
 #>
 function Invoke-BicepBuild {
+    [cmdletbinding()]
     param(
-        [string]$Path = $pwd.path
+        [string]$Path = $pwd.path,
+        [ValidateScript( {
+                if ($_ -like '*.bicep') {
+                    $true
+                }
+                else {
+                    throw "Only .bicep files are allowed as input to -ExcludeFile."
+                }
+            })]
+        [string]$ExcludeFile        
     )
     
     if (TestBicep) {
         $files = Get-Childitem -Path $Path *.bicep -File
         if ($files) {
             foreach ($file in $files) {
-                bicep build $file
+                if ($file.Name -ne $ExcludeFile) {
+                    bicep build $file                
+                }
             }   
         }
         else {


### PR DESCRIPTION
Added an `-ExcludeFile` parameter to `Invoke-BicepBuild`. When using `Invoke-BicepBuild` to compile all .bicep files in a folder the parameter can be used to exclude a .bicep file that is still "work in progres". 

Example: 
`Invoke-BicepBuild -Path C:\Bicep\Modules\ -ExcludeFile subnet.bicep`