### PR TITLE
Fixes issue #8

### DIFF
--- a/Source/Bicep.psd1
+++ b/Source/Bicep.psd1
@@ -12,7 +12,7 @@
 RootModule = 'Bicep.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.1.0'
+ModuleVersion = '1.1.1'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/Source/Private/GenerateParameterFile.ps1
+++ b/Source/Private/GenerateParameterFile.ps1
@@ -15,10 +15,10 @@ function GenerateParameterFile {
         $ParameterObject = $ArmTemplate.Parameters.$ParameterName
         if ($null -eq $ParameterObject.defaultValue) {                               
             if ($ParameterObject.type -eq 'Array') {
-                $defaultValue = '[]'
+                $defaultValue = @()
             }
             elseif ($ParameterObject.type -eq 'Object') {
-                $defaultValue = '{}'
+                $defaultValue = @{}
             }
             else {
                 $defaultValue = ""
@@ -34,5 +34,5 @@ function GenerateParameterFile {
         }                       
     }
     $parameterBase['parameters'] = $parameters
-    $parameterBase | ConvertTo-Json -Depth 100 | Out-File "$($file.DirectoryName)\$filename.parameters.json"
+    ConvertTo-Json -InputObject $parameterBase -Depth 100 | Out-File "$($file.DirectoryName)\$filename.parameters.json"
 }


### PR DESCRIPTION
Fixes issue #8 where `Invoke-BicepBuild -GenerateParameterFiles` cannot handle array and object parameters without default value properly.

Bump version number to 1.1.1