### PR TITLE
Added DestinationPath parameter to GenerateParameterFile

### DIFF
--- a/Source/Private/GenerateParameterFile.ps1
+++ b/Source/Private/GenerateParameterFile.ps1
@@ -2,10 +2,19 @@ function GenerateParameterFile {
     [CmdletBinding(DefaultParameterSetName='FromFile',
                    SupportsShouldProcess)]
     param (
-        [Parameter(ParameterSetName = 'FromFile')]
+        [Parameter(Mandatory,
+                   ParameterSetName = 'FromFile')]
         [object]$File,
-        [parameter(ParameterSetName = 'FromContent')]
-        [string]$Content
+
+        [Parameter(Mandatory,
+                   ParameterSetName = 'FromContent')]
+        [ValidateNotNullOrEmpty()]
+        [string]$Content,
+
+        [Parameter(Mandatory,
+                   ParameterSetName = 'FromContent')]
+        [ValidateNotNullOrEmpty()]
+        [string]$DestinationPath
     )
 
     if ($PSCmdlet.ParameterSetName -eq 'FromFile') {
@@ -46,5 +55,17 @@ function GenerateParameterFile {
         }                       
     }
     $parameterBase['parameters'] = $parameters
-    ConvertTo-Json -InputObject $parameterBase -Depth 100 | Out-File "$($file.DirectoryName)\$filename.parameters.json" -WhatIf:$WhatIfPreference
+    $ConvertedToJson = ConvertTo-Json -InputObject $parameterBase -Depth 100
+    
+    switch ($PSCmdlet.ParameterSetName) {
+        'FromFile' {
+            Out-File -InputObject $ConvertedToJson -FilePath "$($file.DirectoryName)\$filename.parameters.json" -WhatIf:$WhatIfPreference
+        }
+        'FromContent' {
+            Out-File -InputObject $ConvertedToJson -FilePath $DestinationPath -WhatIf:$WhatIfPreference
+        }
+        Default {
+            Write-Error "Unable to generate parameter file. Unknown parameter set: $($PSCmdlet.ParameterSetName)"
+        }
+    }
 }

--- a/Source/Private/WriteBicepDiagnostic.ps1
+++ b/Source/Private/WriteBicepDiagnostic.ps1
@@ -4,7 +4,7 @@ function WriteBicepDiagnostic {
         [Bicep.Core.Diagnostics.Diagnostic]$Diagnostic
     )
         
-    New-Alias -Name 'Write-Info' -Value 'Write-Host' -Option Private
+    New-Alias -Name 'Write-Info' -Value 'Write-Host' -Option Private -WhatIf:$false -Confirm:$false
 
     $Level = $Diagnostic.Level.ToString()
     $Code = $Diagnostic.Code.ToString()

--- a/Source/Public/Build-Bicep.ps1
+++ b/Source/Public/Build-Bicep.ps1
@@ -80,13 +80,15 @@ function Build-Bicep {
                     else {        
                         if($PSBoundParameters.ContainsKey('OutputDirectory')) {
                             $OutputFilePath = Join-Path -Path $OutputDirectory -ChildPath ('{0}.json' -f $file.BaseName)
+                            $ParameterFilePath = Join-Path -Path $OutputDirectory -ChildPath ('{0}.parameters.json' -f $file.BaseName)
                         }
                         else {
                             $OutputFilePath = $file.FullName -replace '\.bicep','.json'
+                            $ParameterFilePath = $file.FullName -replace '\.bicep','.parameters.json'
                         }
                         $null = Out-File -Path $OutputFilePath -InputObject $ARMTemplate -Encoding utf8 -WhatIf:$WhatIfPreference
                         if ($GenerateParameterFile.IsPresent) {
-                            GenerateParameterFile -Content $ARMTemplate -WhatIf:$WhatIfPreference
+                            GenerateParameterFile -Content $ARMTemplate -DestinationPath $ParameterFilePath -WhatIf:$WhatIfPreference
                         }
                     }
                 }


### PR DESCRIPTION
Parameter DestinationPath is added to GenerateParameterFile which can be used in the parameter set FromContent.
Changed the call from Build-Bicep to use this parameter.

Also fixed WriteBicepDiagnostic so that it doesnt give errors when using -WhatIf or -Confirm.

Closes #45