### PR TITLE
Alternative diagnostics

### DIFF
--- a/Docs/Help/Build-Bicep.md
+++ b/Docs/Help/Build-Bicep.md
@@ -27,9 +27,12 @@ Build-Bicep [[-Path] <String>] [[-OutputDirectory] <String>] [-ExcludeFile <Stri
 ## DESCRIPTION
 **Build-Bicep** is equivalent to the Bicep CLI command 'bicep build' but with some additional features.
 
--Compile all files in a directory
--Generate ARM Template Parameter files
--Output ARM Template directly as string without writing to file
+- Compile all files in a directory  
+- Generate ARM Template Parameter files  
+- Output ARM Template directly as string without writing to file  
+  
+Any error or warning from bicep will be written to the information stream.
+To save output in a variable, use stream redirection. See example below.
 
 ## EXAMPLES
 
@@ -63,6 +66,16 @@ Build-Bicep -Path '.\vnet.bicep' -AsString
 Build-Bicep -Path '.\vnet.bicep' -GenerateParameterFile
 ```
 
+### Example 7: Compile a .bicep files in the working directory and store diagnostic messages from bicep in a variable.
+```powershell
+$Diagnostics = Build-Bicep -Path '.\vnet.bicep' 6>&1
+# Messages are tagged and can be sorted.
+$Diagnostics | Where-Object Tags -eq 'Error'
+$Diagnostics | Where-Object Tags -eq 'Warning'
+```
+
+Stores all Errors and Warnings from bicep in variable $Diagnostics.
+Then outputs first all Erros then all Warnings.
 ## PARAMETERS
 
 ### -Path

--- a/Source/Private/ParseBicep.ps1
+++ b/Source/Private/ParseBicep.ps1
@@ -19,10 +19,7 @@ function ParseBicep {
             $DiagnosticResult = $CompilationResults[$SyntaxTree]
             if ($DiagnosticResult.GetCount($false) -gt 0) {
                 foreach ($Diagnostic in $DiagnosticResult) {
-                    # If any diagnostic is an error
-                    if ((WriteBicepDiagnostic -Diagnostic $Diagnostic -SyntaxTree $SyntaxTree) -eq $false) {
-                        $Success = $false
-                    }
+                    $Success = (WriteBicepDiagnostic -Diagnostic $Diagnostic -SyntaxTree $SyntaxTree) -and $Success
                 }
             }
         }
@@ -40,6 +37,15 @@ function ParseBicep {
     
                 Write-Output $String
             }
+        }
+        else {
+            $ErrorParams = @{
+                Message           = "Failed to build bicep file: $Path" 
+                Category          = 'InvalidResult' 
+                RecommendedAction = 'Check for errors in the Information stream.'
+                TargetObject      = $Path
+            }
+            Write-Error @ErrorParams
         }
     }
 }

--- a/Source/Private/WriteBicepDiagnostic.ps1
+++ b/Source/Private/WriteBicepDiagnostic.ps1
@@ -21,15 +21,37 @@ function WriteBicepDiagnostic {
 
     switch ($Diagnostic.Level) {
         'Info' {
-            Write-Host "ERROR: $OutputString"
+            $Params = @{
+                MessageData = [System.Management.Automation.HostInformationMessage]@{
+                    Message         = $OutputString
+                    ForegroundColor = $Host.PrivateData.VerboseForegroundColor
+                    BackgroundColor = $Host.PrivateData.VerboseBackgroundColor
+                }
+                Tag         = 'Information'
+            }
         }
         'Warning' {
-            Write-Warning $OutputString
+            $Params = @{
+                MessageData = [System.Management.Automation.HostInformationMessage]@{
+                    Message         = $OutputString
+                    ForegroundColor = $Host.PrivateData.WarningForegroundColor
+                    BackgroundColor = $Host.PrivateData.WarningBackgroundColor
+                }
+                Tag         = 'Warning'
+            }
         }
         'Error' {
-            WriteErrorStream $OutputString
+            $Params = @{
+                MessageData = [System.Management.Automation.HostInformationMessage]@{
+                    Message         = $OutputString
+                    ForegroundColor = $Host.PrivateData.ErrorForegroundColor
+                    BackgroundColor = $Host.PrivateData.ErrorBackgroundColor
+                }
+                Tag         = 'Error'
+            }
         }
     }
-
-    return ($Diagnostic.Level -eq [Bicep.Core.Diagnostics.DiagnosticLevel]::Error)
+    
+    Write-Information @Params -InformationAction 'Continue'
+    return ($Diagnostic.Level -ne [Bicep.Core.Diagnostics.DiagnosticLevel]::Error)
 }

--- a/Source/Private/WriteBicepDiagnostic.ps1
+++ b/Source/Private/WriteBicepDiagnostic.ps1
@@ -51,7 +51,6 @@ function WriteBicepDiagnostic {
             }
         }
     }
-    
-    Write-Information @Params -InformationAction 'Continue'
-    return ($Diagnostic.Level -ne [Bicep.Core.Diagnostics.DiagnosticLevel]::Error)
+
+    return $Params
 }

--- a/Source/Public/Build-Bicep.ps1
+++ b/Source/Public/Build-Bicep.ps1
@@ -35,10 +35,10 @@ function Build-Bicep {
             foreach ($file in $files) {
                 if ($file.Name -notin $ExcludeFile) {
                     $ARMTemplate = ParseBicep -Path $file.FullName
-                    if ($AsString.IsPresent) {
+                    if (-not [string]::IsNullOrWhiteSpace($ARMTemplate) -and $AsString.IsPresent) {
                         Write-Output $ARMTemplate
                     }
-                    else {        
+                    elseif (-not [string]::IsNullOrWhiteSpace($ARMTemplate)) {        
                         if($PSBoundParameters.ContainsKey('OutputDirectory')) {
                             $OutputFilePath = Join-Path -Path $OutputDirectory -ChildPath ('{0}.json' -f $file.BaseName)
                             $ParameterFilePath = Join-Path -Path $OutputDirectory -ChildPath ('{0}.parameters.json' -f $file.BaseName)

--- a/Source/Public/Build-Bicep.ps1
+++ b/Source/Public/Build-Bicep.ps1
@@ -27,6 +27,13 @@ function Build-Bicep {
         if ($PSBoundParameters.ContainsKey('OutputDirectory') -and (-not (Test-Path $OutputDirectory))) {
             $null = New-Item $OutputDirectory -Force -ItemType Directory -WhatIf:$WhatIfPreference
         }
+
+        if($VerbosePreference -eq [System.Management.Automation.ActionPreference]::Continue) {
+            $DLLPath = [Bicep.Core.Workspaces.Workspace].Assembly.Location
+            $DllFile = Get-Item -Path $DLLPath
+            $FullVersion = $DllFile.VersionInfo.ProductVersion.Split('+')[0]
+            Write-Verbose -Message "Using Bicep version: $FullVersion"
+        }
     }
 
     process {

--- a/Source/Public/ConvertTo-Bicep.ps1
+++ b/Source/Public/ConvertTo-Bicep.ps1
@@ -41,6 +41,7 @@ If you would like to report any issues or inaccurate conversions, please see htt
                             $FilePath = Join-Path -Path $FolderPath -ChildPath $FileName
                         }
                         $null = Out-File -InputObject $BicepObject.Item2[$BicepFile] -FilePath $FilePath -Encoding utf8
+                        $null = Build-Bicep -Path $FilePath -AsString
                     }
                 }
             }

--- a/scripts/downloadAssemblies.ps1
+++ b/scripts/downloadAssemblies.ps1
@@ -16,18 +16,15 @@ try {
     $null = New-Item -Path '../Source/Assets' -ItemType Directory -ErrorAction Ignore
     $AssetsFolder = Resolve-Path -Path '../Source/Assets'
     $AssemblyVersion = Get-Content -Path '../Source/assemblyversion.txt' -ErrorAction 'Stop'
-    $TagUri = '{0}/repos/Azure/bicep/releases/tags/{1}' -f $BaseUri, $AssemblyVersion
-    $TagInfo = Invoke-RestMethod -Method 'GET' -Uri $TagUri
     
     $null = New-Item -Path './tmp' -ItemType Directory -ErrorAction Ignore
     Push-Location -Path './tmp' -StackName 'downloadAssemblies'
-    Write-Verbose -Message 'Downloading Bicep sources'
-    $ProgressPreference = 'SilentlyContinue'
-    Invoke-WebRequest -Uri $TagInfo.zipball_url -OutFile './bicepSource.zip'
-    Write-Verbose -Message 'Extracting sources'
-    Expand-Archive -Path './bicepSource.zip' -Force
-    Push-Location -Path './bicepSource/Azure-bicep-*/src' -StackName 'downloadAssemblies'
-    dotnet publish './Bicep.Decompiler' -c 'Release' --no-self-contained --nologo --verbosity 'minimal'
+    Write-Verbose -Message 'Cloning Bicep sources'
+    git clone 'https://github.com/Azure/bicep.git' *>$null
+    Push-Location -Path './bicep' -StackName 'downloadAssemblies'
+    git checkout tags/$AssemblyVersion *>$null
+    Push-Location -Path './src' -StackName 'downloadAssemblies'
+    dotnet publish './Bicep.Cli' -c 'Release' --no-self-contained --nologo --verbosity 'minimal'
     $FilesToInclude = @(
         'Azure.Bicep.Types.dll',
         'Azure.Bicep.Types.Az.dll',
@@ -36,7 +33,7 @@ try {
         'Bicep.Core.dll',
         'Bicep.Decompiler.dll'
     )
-    $Files = Get-Item -Path '.\Bicep.Decompiler\bin\Release\netstandard2.1\publish\*' -Include $FilesToInclude
+    $Files = Get-Item -Path '.\Bicep.Cli\bin\Release\net5.0\publish\*' -Include $FilesToInclude
     $Files | Copy-Item -Destination $AssetsFolder.Path -Force
 }
 finally {


### PR DESCRIPTION
Now outputs all diagnostic messages to the Information stream

If any errors are output we will write-error to support -ErrorAction Stop

Each diagnostic message will be tagged with Information, Warning or Error to be able to tell them apart programmatically.