### PR TITLE
#59 Added warning to Install-BicepCLI if multiple versions are installed

### DIFF
--- a/Source/Public/Install-BicepCLI.ps1
+++ b/Source/Public/Install-BicepCLI.ps1
@@ -3,9 +3,13 @@ function Install-BicepCLI {
     param(
         [switch]$Force
     )
-    if (-not $Force.IsPresent) {
-        $BicepInstalled=TestBicep
+    
+    $BicepInstalled=TestBicep
+    
+    if ($Force.IsPresent -and $BicepInstalled -eq $true) {
+        Write-Warning 'You are running multiple installations of Bicep CLI. You can correct this by running Update-BicepCLI.'
     }
+
     if ($Force.IsPresent -or $BicepInstalled -eq $false) {
         # Fetch the latest Bicep CLI installer
         $DownloadFileName = 'bicep-setup-win-x64.exe'


### PR DESCRIPTION
If -force flag is used and we find a previously installed version of BicepCLI we now show a warning. 

It is still possible to run the installation, and no uninstallation will be performed, according to discussions.