### PR TITLE
New command Convert-JsonToBicep

### DIFF
--- a/Docs/Help/Convert-JsonToBicep.md
+++ b/Docs/Help/Convert-JsonToBicep.md
@@ -1,0 +1,89 @@
+---
+external help file: Bicep-help.xml
+Module Name: Bicep
+online version:
+schema: 2.0.0
+---
+
+# Convert-JsonToBicep
+
+## SYNOPSIS
+Convert a JSON string to Bicep
+
+## SYNTAX
+
+```
+Convert-JsonToBicep -String <String> [<CommonParameters>]
+```
+
+## DESCRIPTION
+This command converts any valid JSON object to Bicep Language format
+
+## EXAMPLES
+
+### Example 1: Convert a json object to Bicep Language
+```powershell
+Convert-JsonToBicep -String '{"key": "value", "anotherKey": "anotherValue"}'
+```
+
+This example converts a simple JSON object to Bicep Language
+
+### Example 2: Convert a json array to Bicep Language
+```powershell
+$json = @'
+[
+  {
+    "properties": {
+      "NSGName": "subnet2-nsg",
+      "SubnetName": "subnet2",
+      "RouteName": "",
+      "disableBgpRoutePropagation": true,
+      "routes": []
+    }
+  },
+  {
+    "properties": {
+      "NSGName": "subnet3-nsg",
+      "SubnetName": "subnet3",
+      "RouteName": "",
+      "disableBgpRoutePropagation": false,
+      "routes": []
+    }
+  }
+]
+'@
+Convert-JsonToBicep -String $json
+```
+
+This example converts a JSON array to Bicep Language
+
+## PARAMETERS
+
+### -String
+Specifies the JSON string to convert to Bicep Language
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/Source/Bicep.psd1
+++ b/Source/Bicep.psd1
@@ -94,7 +94,8 @@ FunctionsToExport = @(
     'Update-BicepCLI', 
     'Uninstall-BicepCLI', 
     'Get-BicepApiReference',
-    'Update-BicepTypes'
+    'Update-BicepTypes',
+    'Convert-JsonToBicep'
 )
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/Source/Public/Convert-JsonToBicep.ps1
+++ b/Source/Public/Convert-JsonToBicep.ps1
@@ -4,7 +4,10 @@ function Convert-JsonToBicep {
         [Parameter(Mandatory, 
             ParameterSetName = 'String')]
         [ValidateNotNullOrEmpty()]
-        [ValidateScript({$_ | Convertfrom-Json})]
+        [ValidateScript( { 
+                try { $_ | Convertfrom-Json }
+                catch { throw 'The string is not a valid json' }
+            })]
         [string]$String
     )
 
@@ -27,15 +30,13 @@ function Convert-JsonToBicep {
         $files = Get-ChildItem -Path "$($env:TEMP)\tempfile.json"
         
         if ($files) {
-            foreach ($file in $files) {
-                $BicepObject = [Bicep.Decompiler.TemplateDecompiler]::DecompileFileWithModules($ResourceProvider, $FileResolver, $file.FullName)
-                
-                foreach ($BicepFile in $BicepObject.Item2.Keys) {                 
-                    $bicepData = $BicepObject.Item2[$BicepFile]
-                }       
-                $bicepOutput = $bicepData.Replace("var temp = ", "")
-                Write-Host $bicepOutput                            
-            }
-        }
+            $BicepObject = [Bicep.Decompiler.TemplateDecompiler]::DecompileFileWithModules($ResourceProvider, $FileResolver, $files.FullName)
+            foreach ($BicepFile in $BicepObject.Item2.Keys) {                 
+                $bicepData = $BicepObject.Item2[$BicepFile]
+            }       
+            $bicepOutput = $bicepData.Replace("var temp = ", "")
+            Write-Host $bicepOutput                        
+        }        
+        Remove-Item $files
     }
 }

--- a/Source/Public/Convert-JsonToBicep.ps1
+++ b/Source/Public/Convert-JsonToBicep.ps1
@@ -28,16 +28,16 @@ function Convert-JsonToBicep {
         $templateBase['variables'] = $variables
         $tempTemplate = ConvertTo-Json -InputObject $templateBase -Depth 100
         Out-File -InputObject $tempTemplate -FilePath "$($env:TEMP)\tempfile.json"
-        $files = Get-ChildItem -Path "$($env:TEMP)\tempfile.json"
+        $file = Get-ChildItem -Path "$($env:TEMP)\tempfile.json"
         
-        if ($files) {
-            $BicepObject = [Bicep.Decompiler.TemplateDecompiler]::DecompileFileWithModules($ResourceProvider, $FileResolver, $files.FullName)
+        if ($file) {
+            $BicepObject = [Bicep.Decompiler.TemplateDecompiler]::DecompileFileWithModules($ResourceProvider, $FileResolver, $file.FullName)
             foreach ($BicepFile in $BicepObject.Item2.Keys) {                 
                 $bicepData = $BicepObject.Item2[$BicepFile]
             }       
             $bicepOutput = $bicepData.Replace("var temp = ", "")
             Write-Host $bicepOutput                        
         }        
-        Remove-Item $files
+        Remove-Item $file
     }
 }

--- a/Source/Public/Convert-JsonToBicep.ps1
+++ b/Source/Public/Convert-JsonToBicep.ps1
@@ -5,9 +5,10 @@ function Convert-JsonToBicep {
             ParameterSetName = 'String')]
         [ValidateNotNullOrEmpty()]
         [ValidateScript( { 
-                try { $_ | Convertfrom-Json }
-                catch { throw 'The string is not a valid json' }
-            })]
+            try { $_ | Convertfrom-Json }
+            catch { $false }
+          },
+          ErrorMessage = 'The string is not a valid json')]
         [string]$String
     )
 

--- a/Source/Public/Convert-JsonToBicep.ps1
+++ b/Source/Public/Convert-JsonToBicep.ps1
@@ -1,0 +1,41 @@
+function Convert-JsonToBicep {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory, 
+            ParameterSetName = 'String')]
+        [ValidateNotNullOrEmpty()]
+        [ValidateScript({$_ | Convertfrom-Json})]
+        [string]$String
+    )
+
+    begin {        
+        $FileResolver = [Bicep.Core.FileSystem.FileResolver]::new()
+        $ResourceProvider = [Bicep.Core.TypeSystem.Az.AzResourceTypeProvider]::new()
+    }
+
+    process {
+        $jsonObject = ConvertFrom-Json -InputObject $String -AsHashtable -Depth 100
+        $variables = [ordered]@{}
+        $templateBase = [ordered]@{
+            '$schema'        = 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
+            'contentVersion' = '1.0.0.0'
+        }
+        $variables['temp'] = $jsonObject                                  
+        $templateBase['variables'] = $variables
+        $tempTemplate = ConvertTo-Json -InputObject $templateBase -Depth 100
+        Out-File -InputObject $tempTemplate -FilePath "$($env:TEMP)\tempfile.json"
+        $files = Get-ChildItem -Path "$($env:TEMP)\tempfile.json"
+        
+        if ($files) {
+            foreach ($file in $files) {
+                $BicepObject = [Bicep.Decompiler.TemplateDecompiler]::DecompileFileWithModules($ResourceProvider, $FileResolver, $file.FullName)
+                
+                foreach ($BicepFile in $BicepObject.Item2.Keys) {                 
+                    $bicepData = $BicepObject.Item2[$BicepFile]
+                }       
+                $bicepOutput = $bicepData.Replace("var temp = ", "")
+                Write-Host $bicepOutput                            
+            }
+        }
+    }
+}

--- a/Source/en-US/Bicep-help.xml
+++ b/Source/en-US/Bicep-help.xml
@@ -406,6 +406,114 @@ New-AzResourceGroupDeployment -ResourceGroupName vnet-rg -TemplateObject $Templa
   </command:command>
   <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
     <command:details>
+      <command:name>Convert-JsonToBicep</command:name>
+      <command:verb>Convert</command:verb>
+      <command:noun>JsonToBicep</command:noun>
+      <maml:description>
+        <maml:para>Convert a JSON string to Bicep</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>This command converts any valid JSON object to Bicep Language format</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Convert-JsonToBicep</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>String</maml:name>
+          <maml:description>
+            <maml:para>Specifies the JSON string to convert to Bicep Language</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>String</maml:name>
+        <maml:description>
+          <maml:para>Specifies the JSON string to convert to Bicep Language</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>------ Example 1: Convert a json object to Bicep Language ------</maml:title>
+        <dev:code>Convert-JsonToBicep -String '{"key": "value", "anotherKey": "anotherValue"}'</dev:code>
+        <dev:remarks>
+          <maml:para>This example converts a simple JSON object to Bicep Language</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>------ Example 2: Convert a json array to Bicep Language ------</maml:title>
+        <dev:code>$json = @'
+[
+  {
+    "properties": {
+      "NSGName": "subnet2-nsg",
+      "SubnetName": "subnet2",
+      "RouteName": "",
+      "disableBgpRoutePropagation": true,
+      "routes": []
+    }
+  },
+  {
+    "properties": {
+      "NSGName": "subnet3-nsg",
+      "SubnetName": "subnet3",
+      "RouteName": "",
+      "disableBgpRoutePropagation": false,
+      "routes": []
+    }
+  }
+]
+'@
+Convert-JsonToBicep -String $json</dev:code>
+        <dev:remarks>
+          <maml:para>This example converts a JSON array to Bicep Language</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
       <command:name>ConvertTo-Bicep</command:name>
       <command:verb>ConvertTo</command:verb>
       <command:noun>Bicep</command:noun>


### PR DESCRIPTION
A first draft to fix feature request #105.

To use the feature:
```
$json = @"
[
  {
    "properties": {
      "NSGName": "subnet2-nsg",
      "SubnetName": "subnet2",
      "RouteName": "",
      "disableBgpRoutePropagation": true,
      "routes": []
    }
  },
  {
    "properties": {
      "NSGName": "subnet3-nsg",
      "SubnetName": "subnet3",
      "RouteName": "",
      "disableBgpRoutePropagation": false,
      "routes": []
    }
  }
]
"@
Convert-JsonToBicep -String $jsonSnippet
```
Or:
`Convert-JsonToBicep -String '{"key": "value", "anotherKey": "anotherValue"}'`
