### PR TITLE
fix: bicep command casing (fixes #107)

### DIFF
--- a/Source/Private/TestBicep.ps1
+++ b/Source/Private/TestBicep.ps1
@@ -1,5 +1,5 @@
 function TestBicep {
-    $bicep = (Get-Command Bicep -ErrorAction SilentlyContinue)
+    $bicep = (Get-Command bicep -ErrorAction SilentlyContinue)
     if ($bicep) {
         $true
     }


### PR DESCRIPTION
The executable is by default installed as `bicep` and not `Bicep`.

For cross-plattform compability and to be consistent with InstalledBicepVersion.ps1 the bicep command is changed from `Bicep` to `bicep` in TestBicep.ps1.

Closes #107