### PR TITLE
Convert-JsonToBicep: Use safe path for tmp/temp and allow pipeline input

### DIFF
--- a/Docs/Help/Convert-JsonToBicep.md
+++ b/Docs/Help/Convert-JsonToBicep.md
@@ -62,7 +62,7 @@ This example converts a JSON array to Bicep Language
 Get-Content -Path <path to .json file> -Raw | Convert-JsonToBicep
 ```
 
-This exampe converts a JSON file to Bicep Language
+This example converts a JSON file to Bicep Language
 
 ## PARAMETERS
 

--- a/Docs/Help/Convert-JsonToBicep.md
+++ b/Docs/Help/Convert-JsonToBicep.md
@@ -57,6 +57,13 @@ Convert-JsonToBicep -String $json
 
 This example converts a JSON array to Bicep Language
 
+### Example 3: Read a file and convert to Bicep Language
+```powershell
+Get-Content -Path <path to .json file> -Raw | Convert-JsonToBicep
+```
+
+This exampe converts a JSON file to Bicep Language
+
 ## PARAMETERS
 
 ### -String

--- a/Source/Public/Convert-JsonToBicep.ps1
+++ b/Source/Public/Convert-JsonToBicep.ps1
@@ -1,20 +1,22 @@
 function Convert-JsonToBicep {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory, 
+        [Parameter(Mandatory,
+            ValueFromPipeline = $true,
             ParameterSetName = 'String')]
         [ValidateNotNullOrEmpty()]
-        [ValidateScript( { 
-            try { $_ | Convertfrom-Json }
-            catch { $false }
-          },
-          ErrorMessage = 'The string is not a valid json')]
+        [ValidateScript( {
+                try { $_ | Convertfrom-Json }
+                catch { $false }
+            },
+            ErrorMessage = 'The string is not a valid json')]
         [string]$String
     )
 
-    begin {        
+    begin {
         $FileResolver = [Bicep.Core.FileSystem.FileResolver]::new()
         $ResourceProvider = [Bicep.Core.TypeSystem.Az.AzResourceTypeProvider]::new()
+        $tempPath = [System.Io.Path]::GetTempPath()
     }
 
     process {
@@ -24,20 +26,20 @@ function Convert-JsonToBicep {
             '$schema'        = 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
             'contentVersion' = '1.0.0.0'
         }
-        $variables['temp'] = $jsonObject                                  
+        $variables['temp'] = $jsonObject
         $templateBase['variables'] = $variables
         $tempTemplate = ConvertTo-Json -InputObject $templateBase -Depth 100
-        Out-File -InputObject $tempTemplate -FilePath "$($env:TEMP)\tempfile.json"
-        $file = Get-ChildItem -Path "$($env:TEMP)\tempfile.json"
-        
+        Out-File -InputObject $tempTemplate -FilePath "$tempPath\tempfile.json"
+        $file = Get-ChildItem -Path "$tempPath\tempfile.json"
+
         if ($file) {
             $BicepObject = [Bicep.Decompiler.TemplateDecompiler]::DecompileFileWithModules($ResourceProvider, $FileResolver, $file.FullName)
-            foreach ($BicepFile in $BicepObject.Item2.Keys) {                 
+            foreach ($BicepFile in $BicepObject.Item2.Keys) {
                 $bicepData = $BicepObject.Item2[$BicepFile]
-            }       
+            }
             $bicepOutput = $bicepData.Replace("var temp = ", "")
-            Write-Host $bicepOutput                        
-        }        
+            Write-Host $bicepOutput
+        }
         Remove-Item $file
     }
 }


### PR DESCRIPTION
This includes one functional fix, and two minor details.

1) Safe method for getting path to temp directory

Using `$env:TEMP` is a Windows-only way of getting the temp directory.
By replacing this with `[System.Io.Path]::GetTempPath()` it allows
the Convert-JsonToBicep function to work across all platforms.

2) Allow Convert-JsonToBicep to receive pipeline input

This allows the function to process pipeline input to be used
in common Powershell scripting patterns.

3) Trailing whitespace removals (editor formatting, yay)