### PR TITLE
fix: Error message on Windows-only commands for Mac/Linux

### DIFF
--- a/Docs/Help/Install-BicepCLI.md
+++ b/Docs/Help/Install-BicepCLI.md
@@ -8,8 +8,7 @@ schema: 2.0.0
 # Install-BicepCLI
 
 ## SYNOPSIS
-
-Install Bicep CLI
+Install Bicep CLI (Windows only)
 
 ## SYNTAX
 

--- a/Docs/Help/Uninstall-BicepCLI.md
+++ b/Docs/Help/Uninstall-BicepCLI.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 # Uninstall-BicepCLI
 
 ## SYNOPSIS
-Uninstall Bicep CLI
+Uninstall Bicep CLI (Windows only)
 
 ## SYNTAX
 

--- a/Docs/Help/Update-BicepCLI.md
+++ b/Docs/Help/Update-BicepCLI.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 # Update-BicepCLI
 
 ## SYNOPSIS
-Update Bicep CLI
+Update Bicep CLI (Windows only)
 
 ## SYNTAX
 

--- a/Source/Public/Install-BicepCLI.ps1
+++ b/Source/Public/Install-BicepCLI.ps1
@@ -1,23 +1,30 @@
 function Install-BicepCLI {
     [CmdLetBinding()]
     param(
-        [ValidateScript( { (ListBicepVersions).Contains($_) }, 
+        [ValidateScript( { (ListBicepVersions).Contains($_) },
             ErrorMessage = "Bicep Version '{0}' was not found.")]
         [ArgumentCompleter([BicepVersionCompleter])]
         [string]$Version,
-        [switch]$Force        
+        [switch]$Force
     )
-    
+
     $BicepInstalled = TestBicep
-    
+
+    if (!($IsWindows)) {
+        Write-Error -Message "This cmdlet is only supported for Windows systems. `
+To install Bicep on your system see instructions on https://github.com/Azure/bicep"
+        Write-Host "`nList the available module cmdlets by running 'Get-Help -Name Bicep'`n"
+        break
+    }
+
     $BaseURL = 'https://api.github.com/repos/Azure/bicep/releases'
     if ($PSBoundParameters.ContainsKey('Version')) {
-        $BicepRelease = ('{0}/tags/v{1}' -f $BaseURL, $Version)  
+        $BicepRelease = ('{0}/tags/v{1}' -f $BaseURL, $Version)
     }
     else {
         $BicepRelease = ('{0}/latest' -f $BaseURL)
     }
-        
+
     if ($Force.IsPresent -and $BicepInstalled -eq $true) {
         Write-Warning 'You are running multiple installations of Bicep CLI. You can correct this by running Update-BicepCLI.'
     }
@@ -48,13 +55,13 @@ function Install-BicepCLI {
         $i = 0
         do {
             $i++
-            Write-Progress -Activity 'Installing Bicep CLI' -CurrentOperation "$i - Running $DownloadFileName" 
+            Write-Progress -Activity 'Installing Bicep CLI' -CurrentOperation "$i - Running $DownloadFileName"
             Start-Sleep -Seconds 1
-        } while (Get-Process $DownloadFileName.Replace('.exe', '') -ErrorAction SilentlyContinue)   
+        } while (Get-Process $DownloadFileName.Replace('.exe', '') -ErrorAction SilentlyContinue)
 
         # Since bicep installer updates the $env:PATH we reload it in order to verify installation.
         $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
-        
+
         # Verify you can now access the 'bicep' command.
         if (TestBicep) {
             $bicep = InstalledBicepVersion
@@ -73,7 +80,7 @@ function Install-BicepCLI {
             Write-Host "The latest Bicep CLI Version is already installed."
         }
         else {
-            Write-Host "Bicep CLI is already installed, but there is a newer release available. Use Update-BicepCLI or Install-BicepCLI -Force to updated to the latest release"   
-        }        
+            Write-Host "Bicep CLI is already installed, but there is a newer release available. Use Update-BicepCLI or Install-BicepCLI -Force to updated to the latest release"
+        }
     }
 }

--- a/Source/Public/Uninstall-BicepCLI.ps1
+++ b/Source/Public/Uninstall-BicepCLI.ps1
@@ -3,7 +3,14 @@ function Uninstall-BicepCLI {
     param (
         [switch]$Force
     )
-    
+
+    if (!($IsWindows)) {
+        Write-Error -Message "This cmdlet is only supported for Windows systems. `
+To uninstall Bicep on your system see instructions on https://github.com/Azure/bicep"
+        Write-Host "`nList the available module cmdlets by running 'Get-Help -Name Bicep'`n"
+        break
+    }
+
     if (TestBicep) {
         # Test if we are running as administrators.
         $currentPrincipal = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
@@ -15,10 +22,10 @@ function Uninstall-BicepCLI {
         if (-not $IsAdmin -and $Force) {
             Write-Host 'You are not running elevated. We may not be able to remove all parts.'
         }
-        if ($IsAdmin -or $Force) {    
+        if ($IsAdmin -or $Force) {
             $UninstallerFileName = 'unins000.exe'
             $BicepExeName = 'bicep.exe'
-            $BicepInstalls = $env:Path -split ';' | Where-Object { $_ -like "*\.bicep" -or $_ -like "*\Bicep CLI" } 
+            $BicepInstalls = $env:Path -split ';' | Where-Object { $_ -like "*\.bicep" -or $_ -like "*\Bicep CLI" }
 
             foreach ($Install in $BicepInstalls) {
                 $FileContents = Get-ChildItem $Install
@@ -48,7 +55,7 @@ function Uninstall-BicepCLI {
             else {
                 Write-Host "Successfully removed bicep."
             }
-        
+
         }
     }
     else {

--- a/Source/Public/Update-BicepCLI.ps1
+++ b/Source/Public/Update-BicepCLI.ps1
@@ -15,7 +15,7 @@ To update Bicep on your system see instructions on https://github.com/Azure/bice
     if ($versionCheck) {
         Write-Host "You are already running the latest version of Bicep CLI."
     }
-    elseif ($isWindows) {
+    else {
         Uninstall-BicepCLI -Force -ErrorAction SilentlyContinue
         Install-BicepCLI -Force
     }

--- a/Source/Public/Update-BicepCLI.ps1
+++ b/Source/Public/Update-BicepCLI.ps1
@@ -2,14 +2,21 @@ function Update-BicepCLI {
     [CmdletBinding()]
     param (
     )
-    
+
+    if (!($IsWindows)) {
+        Write-Error -Message "This cmdlet is only supported for Windows systems. `
+To update Bicep on your system see instructions on https://github.com/Azure/bicep"
+        Write-Host "Compare your Bicep version with latest version by running Get-BicepVersion"
+        break
+    }
+
     $versionCheck = CompareBicepVersion
 
     if ($versionCheck) {
         Write-Host "You are already running the latest version of Bicep CLI."
     }
-    else {
+    elseif ($isWindows) {
         Uninstall-BicepCLI -Force -ErrorAction SilentlyContinue
         Install-BicepCLI -Force
-    }     
+    }
 }

--- a/Source/Public/Update-BicepCLI.ps1
+++ b/Source/Public/Update-BicepCLI.ps1
@@ -6,7 +6,7 @@ function Update-BicepCLI {
     if (!($IsWindows)) {
         Write-Error -Message "This cmdlet is only supported for Windows systems. `
 To update Bicep on your system see instructions on https://github.com/Azure/bicep"
-        Write-Host "Compare your Bicep version with latest version by running Get-BicepVersion"
+        Write-Host "`nCompare your Bicep version with latest version by running Get-BicepVersion`n"
         break
     }
 

--- a/Source/en-US/Bicep-help.xml
+++ b/Source/en-US/Bicep-help.xml
@@ -917,7 +917,7 @@ Convert-JsonToBicep -String $json</dev:code>
       <command:verb>Install</command:verb>
       <command:noun>BicepCLI</command:noun>
       <maml:description>
-        <maml:para>Install Bicep CLI</maml:para>
+        <maml:para>Install Bicep CLI (Windows only)</maml:para>
       </maml:description>
     </command:details>
     <maml:description>
@@ -1008,7 +1008,7 @@ Convert-JsonToBicep -String $json</dev:code>
       <command:verb>Uninstall</command:verb>
       <command:noun>BicepCLI</command:noun>
       <maml:description>
-        <maml:para>Uninstall Bicep CLI</maml:para>
+        <maml:para>Uninstall Bicep CLI (Windows only)</maml:para>
       </maml:description>
     </command:details>
     <maml:description>
@@ -1086,7 +1086,7 @@ Convert-JsonToBicep -String $json</dev:code>
       <command:verb>Update</command:verb>
       <command:noun>BicepCLI</command:noun>
       <maml:description>
-        <maml:para>Update Bicep CLI</maml:para>
+        <maml:para>Update Bicep CLI (Windows only)</maml:para>
       </maml:description>
     </command:details>
     <maml:description>


### PR DESCRIPTION
Adds error/info message and exits from

- Install-BicepCLI
- Update-BicepCLI
- Uninstall-BicepCLI

on non-Windows systems.

Closes #116