### PR TITLE
New command Convert-BicepParamsToDecoratorStyle

### DIFF
--- a/.github/workflows/RunTests.yaml
+++ b/.github/workflows/RunTests.yaml
@@ -20,7 +20,7 @@ jobs:
       shell: pwsh
       run: ./scripts/downloadDependencies.ps1
     - name: Import required modules
-      run: Install-Module -Name Pester -Force
+      run: Install-Module -Name Pester -RequiredVersion 5.1.1 -Force
       shell: pwsh
     - name: Run Pester tests and build module
       run: | 

--- a/Docs/Help/Build-Bicep.md
+++ b/Docs/Help/Build-Bicep.md
@@ -15,19 +15,19 @@ Builds one or more .bicep files.
 ### Default (Default)
 ```
 Build-Bicep [[-Path] <String>] [[-OutputDirectory] <String>] [-ExcludeFile <String[]>] [-GenerateParameterFile]
- [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-IgnoreDiagnostics] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### AsHashtable
 ```
-Build-Bicep [[-Path] <String>] [[-OutputDirectory] <String>] [-ExcludeFile <String[]>] [-AsHashtable] [-WhatIf]
+Build-Bicep [[-Path] <String>] [-ExcludeFile <String[]>] [-AsHashtable] [-IgnoreDiagnostics] [-WhatIf]
  [-Confirm] [<CommonParameters>]
 ```
 
 ### AsString
 ```
-Build-Bicep [[-Path] <String>] [[-OutputDirectory] <String>] [-ExcludeFile <String[]>] [-AsString] [-WhatIf]
- [-Confirm] [<CommonParameters>]
+Build-Bicep [[-Path] <String>] [-ExcludeFile <String[]>] [-AsString] [-IgnoreDiagnostics] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -89,6 +89,11 @@ $Template=Build-Bicep -Path '.\vnet.bicep' -AsHashtable
 New-AzResourceGroupDeployment -ResourceGroupName vnet-rg -TemplateObject $Template
 ```
 
+### Example 8: Compile a .bicep and ignore all build warnings and errors
+```powershell
+Build-Bicep -Path '.\vnet.bicep' -IgnoreDiagnostics
+```
+
 
 ## PARAMETERS
 
@@ -112,7 +117,7 @@ Specfies the target directory where the compiled files should be created
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: Default
 Aliases:
 
 Required: False
@@ -204,6 +209,21 @@ Shows what would happen if the cmdlet runs. The cmdlet is not run.
 Type: SwitchParameter
 Parameter Sets: (All)
 Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IgnoreDiagnostics
+Ignores all build warnings and errors.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
 
 Required: False
 Position: Named

--- a/Docs/Help/Convert-BicepParamsToDecoratorStyle.md
+++ b/Docs/Help/Convert-BicepParamsToDecoratorStyle.md
@@ -52,7 +52,7 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -ToClipboard
+### -ToClipboard  (Windows only)
 Saves the converted params to the clipboard.
 
 ```yaml

--- a/Docs/Help/Convert-BicepParamsToDecoratorStyle.md
+++ b/Docs/Help/Convert-BicepParamsToDecoratorStyle.md
@@ -1,0 +1,60 @@
+---
+external help file: Bicep-help.xml
+Module Name: Bicep
+online version:
+schema: 2.0.0
+---
+
+# Convert-BicepParamsToDecoratorStyle
+
+## SYNOPSIS
+Convert Bicep parameters from v0.1-0.2 style to decorator style.
+
+## SYNTAX
+
+```
+Convert-BicepParamsToDecoratorStyle -Path <String> [<CommonParameters>]
+```
+
+## DESCRIPTION
+This command convert Bicep parameters from v0.1-0.2 style to decorator style using a bicep file as input.
+
+## EXAMPLES
+
+### Example 1: Convert parameters from one bicep file to decorator style parameters
+```powershell
+Convert-BicepParamsToDecoratorStyle -Path .\VirtualHubVPNGateway.bicep
+```
+
+This example takes a bicep file as input and converts all parameters to decorator style parameters and outputs the result.
+
+## PARAMETERS
+
+### -Path
+Specfies the path to the file with parameters to convert
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/Docs/Help/Convert-BicepParamsToDecoratorStyle.md
+++ b/Docs/Help/Convert-BicepParamsToDecoratorStyle.md
@@ -13,7 +13,7 @@ Convert Bicep parameters from v0.1-0.2 style to decorator style.
 ## SYNTAX
 
 ```
-Convert-BicepParamsToDecoratorStyle -Path <String> [<CommonParameters>]
+Convert-BicepParamsToDecoratorStyle -Path <String> [-ToClipboard] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -28,6 +28,13 @@ Convert-BicepParamsToDecoratorStyle -Path .\VirtualHubVPNGateway.bicep
 
 This example takes a bicep file as input and converts all parameters to decorator style parameters and outputs the result.
 
+### Example 2: Convert parameters from one bicep file to decorator style parameters and save to clipboard
+```powershell
+Convert-BicepParamsToDecoratorStyle -Path .\VirtualHubVPNGateway.bicep -ToClipboard
+```
+
+This example takes a bicep file as input and converts all parameters to decorator style parameters saves the result to the clipboard.
+
 ## PARAMETERS
 
 ### -Path
@@ -39,6 +46,21 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ToClipboard
+Saves the converted params to the clipboard.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/Source/Bicep.psd1
+++ b/Source/Bicep.psd1
@@ -97,7 +97,8 @@ FunctionsToExport = @(
     'Get-BicepApiReference',
     'Update-BicepTypes',
     'Convert-JsonToBicep',
-    'Convert-BicepParamsToDecoratorStyle'
+    'Convert-BicepParamsToDecoratorStyle',
+    'New-BicepParameterFile'
 )
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/Source/Bicep.psd1
+++ b/Source/Bicep.psd1
@@ -12,7 +12,7 @@
 RootModule = 'Bicep.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.4.5'
+ModuleVersion = '1.4.6'
 
 # Supported PSEditions
 CompatiblePSEditions = @('Core')

--- a/Source/Bicep.psd1
+++ b/Source/Bicep.psd1
@@ -96,7 +96,8 @@ FunctionsToExport = @(
     'Uninstall-BicepCLI', 
     'Get-BicepApiReference',
     'Update-BicepTypes',
-    'Convert-JsonToBicep'
+    'Convert-JsonToBicep',
+    'Convert-BicepParamsToDecoratorStyle'
 )
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/Source/Private/ConvertToHashtable.ps1
+++ b/Source/Private/ConvertToHashtable.ps1
@@ -1,27 +1,42 @@
 function ConvertToHashtable {
     param(
+        [Parameter(ValueFromPipeline)]
         [object]
         $InputObject,
         [switch]
         $Ordered
     )
-    if ($Ordered.IsPresent) {
-        $HashTable = [ordered]@{}
-    }
-    else {
-        $HashTable = @{}
-    }
-    foreach ($Prop in $InputObject.psobject.Properties) {
-        if ($null -eq $Prop.Value) {
-            $HashTable.Add($Prop.Name, $Prop.Value)
+    process {
+
+        # If InputObject is string or valuetype, don't recurse, just return the value.
+        if(
+            $null -eq $InputObject -or 
+            $InputObject.GetType().FullName -eq 'System.String' -or 
+            $InputObject.GetType().IsValueType
+        ) {
+            return $InputObject
         }
-        elseif ($Prop.TypeNameOfValue -eq 'System.String' -or $Prop.Value.GetType().IsValueType) {
-            $HashTable.Add($Prop.Name, $Prop.Value)
+
+        # Else,  create a hashtable and loop over properties.
+        if ($Ordered.IsPresent) {
+            $HashTable = [ordered]@{}
         }
         else {
-            $Value = ConvertToHashtable -InputObject $Prop.Value -Ordered:$Ordered
-            $HashTable.Add($Prop.Name, $Value)
+            $HashTable = @{}
         }
+        foreach ($Prop in $InputObject.psobject.Properties) {
+            if (
+                $null -eq $Prop.Value -or 
+                $Prop.TypeNameOfValue -eq 'System.String' -or 
+                $Prop.Value.GetType().IsValueType
+            ) {
+                $HashTable.Add($Prop.Name, $Prop.Value)
+            }
+            else{
+                $Value = $Prop.Value | ConvertToHashtable -Ordered:$Ordered
+                $HashTable.Add($Prop.Name, $Value)
+            }
+        }
+        return $HashTable
     }
-    $HashTable
 }

--- a/Source/Private/ParseBicep.ps1
+++ b/Source/Private/ParseBicep.ps1
@@ -10,7 +10,7 @@ function ParseBicep {
         $FileResolver = [Bicep.Core.FileSystem.FileResolver]::new()
         $WorkSpace = [Bicep.Core.Workspaces.Workspace]::new()
         $PathHelper = [Bicep.Core.FileSystem.PathHelper]::FilePathToFileUrl($Path)
-        $ResourceTypeProvider = [Bicep.Core.TypeSystem.Az.AzResourceTypeProvider]::new()
+        $ResourceTypeProvider = [Bicep.Core.TypeSystem.Az.AzResourceTypeProvider]::CreateWithAzTypes()
         $SyntaxTreeGrouping = [Bicep.Core.Syntax.SyntaxTreeGroupingBuilder]::Build($FileResolver, $WorkSpace, $PathHelper)
         $Compilation = [Bicep.Core.Semantics.Compilation]::new($ResourceTypeProvider, $SyntaxTreeGrouping)
         $CompilationResults = $Compilation.GetAllDiagnosticsBySyntaxTree()

--- a/Source/Private/ParseBicep.ps1
+++ b/Source/Private/ParseBicep.ps1
@@ -22,11 +22,10 @@ function ParseBicep {
                 foreach ($Diagnostic in $DiagnosticResult) {
                     
                     $Params = WriteBicepDiagnostic -Diagnostic $Diagnostic -SyntaxTree $SyntaxTree
-                    if ($IgnoreWarnings.IsPresent) {} else {
+                    if ( -not $IgnoreWarnings.IsPresent) {
                         Write-Information @Params -InformationAction 'Continue'
-                        Write-Output $Params
-                    }
-
+                    }                    
+                    Write-Output $Params
                     if ($Diagnostic.Level -eq [Bicep.Core.Diagnostics.DiagnosticLevel]::Error) {
                         $Success = $false
                     }

--- a/Source/Private/ParseBicep.ps1
+++ b/Source/Private/ParseBicep.ps1
@@ -19,16 +19,16 @@ function ParseBicep {
         $DiagnosticParams = foreach ($SyntaxTree in $CompilationResults.Keys) {
             $DiagnosticResult = $CompilationResults[$SyntaxTree]
             if ($DiagnosticResult.GetCount($false) -gt 0) {
-                foreach ($Diagnostic in $DiagnosticResult) {
+                if ( -not $IgnoreWarnings.IsPresent) {
+                    foreach ($Diagnostic in $DiagnosticResult) {
                     
-                    $Params = WriteBicepDiagnostic -Diagnostic $Diagnostic -SyntaxTree $SyntaxTree
-                    if ( -not $IgnoreWarnings.IsPresent) {
+                        $Params = WriteBicepDiagnostic -Diagnostic $Diagnostic -SyntaxTree $SyntaxTree
                         Write-Information @Params -InformationAction 'Continue'
+                        Write-Output $Params
+                        if ($Diagnostic.Level -eq [Bicep.Core.Diagnostics.DiagnosticLevel]::Error) {
+                            $Success = $false
+                        }
                     }                    
-                    Write-Output $Params
-                    if ($Diagnostic.Level -eq [Bicep.Core.Diagnostics.DiagnosticLevel]::Error) {
-                        $Success = $false
-                    }
                 }
             }
         }

--- a/Source/Private/ParseBicep.ps1
+++ b/Source/Private/ParseBicep.ps1
@@ -3,7 +3,7 @@ function ParseBicep {
     param (
         [ValidateNotNullOrEmpty()]
         $Path,
-        [switch]$IgnoreWarnings
+        [switch]$IgnoreDiagnostics
     )
 
     process {
@@ -19,7 +19,7 @@ function ParseBicep {
         $DiagnosticParams = foreach ($SyntaxTree in $CompilationResults.Keys) {
             $DiagnosticResult = $CompilationResults[$SyntaxTree]
             if ($DiagnosticResult.GetCount($false) -gt 0) {
-                if ( -not $IgnoreWarnings.IsPresent) {
+                if ( -not $IgnoreDiagnostics.IsPresent) {
                     foreach ($Diagnostic in $DiagnosticResult) {
                     
                         $Params = WriteBicepDiagnostic -Diagnostic $Diagnostic -SyntaxTree $SyntaxTree

--- a/Source/Private/ParseBicep.ps1
+++ b/Source/Private/ParseBicep.ps1
@@ -2,7 +2,8 @@ function ParseBicep {
     [CmdletBinding()]
     param (
         [ValidateNotNullOrEmpty()]
-        $Path
+        $Path,
+        [switch]$IgnoreWarnings
     )
 
     process {
@@ -19,9 +20,12 @@ function ParseBicep {
             $DiagnosticResult = $CompilationResults[$SyntaxTree]
             if ($DiagnosticResult.GetCount($false) -gt 0) {
                 foreach ($Diagnostic in $DiagnosticResult) {
+                    
                     $Params = WriteBicepDiagnostic -Diagnostic $Diagnostic -SyntaxTree $SyntaxTree
-                    Write-Information @Params -InformationAction 'Continue'
-                    Write-Output $Params
+                    if ($IgnoreWarnings.IsPresent) {} else {
+                        Write-Information @Params -InformationAction 'Continue'
+                        Write-Output $Params
+                    }
 
                     if ($Diagnostic.Level -eq [Bicep.Core.Diagnostics.DiagnosticLevel]::Error) {
                         $Success = $false

--- a/Source/Public/Build-Bicep.ps1
+++ b/Source/Public/Build-Bicep.ps1
@@ -26,7 +26,7 @@ function Build-Bicep {
         [Parameter(ParameterSetName = 'AsHashtable')]
         [switch]$AsHashtable,
 
-        [switch]$IgnoreWarnings
+        [switch]$IgnoreDiagnostics
     )
 
     
@@ -51,8 +51,8 @@ function Build-Bicep {
         if ($files) {
             foreach ($file in $files) {
                 if ($file.Name -notin $ExcludeFile) {
-                    if ($IgnoreWarnings.IsPresent) {
-                        $ARMTemplate = ParseBicep -Path $file.FullName -IgnoreWarnings
+                    if ($IgnoreDiagnostics.IsPresent) {
+                        $ARMTemplate = ParseBicep -Path $file.FullName -IgnoreDiagnostics
                     } else {
                         $ARMTemplate = ParseBicep -Path $file.FullName
                     }

--- a/Source/Public/Build-Bicep.ps1
+++ b/Source/Public/Build-Bicep.ps1
@@ -24,7 +24,9 @@ function Build-Bicep {
         [switch]$AsString,
 
         [Parameter(ParameterSetName = 'AsHashtable')]
-        [switch]$AsHashtable
+        [switch]$AsHashtable,
+
+        [switch]$IgnoreWarnings
     )
 
     
@@ -49,7 +51,11 @@ function Build-Bicep {
         if ($files) {
             foreach ($file in $files) {
                 if ($file.Name -notin $ExcludeFile) {
-                    $ARMTemplate = ParseBicep -Path $file.FullName
+                    if ($IgnoreWarnings.IsPresent) {
+                        $ARMTemplate = ParseBicep -Path $file.FullName -IgnoreWarnings
+                    } else {
+                        $ARMTemplate = ParseBicep -Path $file.FullName
+                    }
                     if (-not [string]::IsNullOrWhiteSpace($ARMTemplate)) {
                         $BicepModuleVersion = (Get-Module -Name Bicep).Version | Sort-Object -Descending | Select-Object -First 1
                         $ARMTemplateObject = ConvertFrom-Json -InputObject $ARMTemplate

--- a/Source/Public/Build-Bicep.ps1
+++ b/Source/Public/Build-Bicep.ps1
@@ -82,7 +82,7 @@ function Build-Bicep {
                             Write-Output $ARMTemplate
                         }
                         elseif ($AsHashtable.IsPresent) {
-                            $ARMTemplate | ConvertFrom-Json -AsHashtable
+                            $ARMTemplateObject | ConvertToHashtable -Ordered
                         }
                         else {        
                             if ($PSBoundParameters.ContainsKey('OutputPath')) {

--- a/Source/Public/Convert-BicepParamsToDecoratorStyle.ps1
+++ b/Source/Public/Convert-BicepParamsToDecoratorStyle.ps1
@@ -1,0 +1,41 @@
+function Convert-BicepParamsToDecoratorStyle {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory,
+            ParameterSetName = 'Default')]
+        [ValidateNotNullOrEmpty()]
+        [string]$Path
+    )
+
+    begin {
+        $FileResolver = [Bicep.Core.FileSystem.FileResolver]::new()
+        $ResourceProvider = [Bicep.Core.TypeSystem.Az.AzResourceTypeProvider]::new()
+        $tempPath = [System.Io.Path]::GetTempPath()
+    }
+
+    process {
+        $armHashTable = Build-Bicep -Path $Path -AsHashtable -IgnoreWarnings
+        $paramHashTable = $armHashTable.parameters
+
+        $parameters = [ordered]@{}
+        $templateBase = [ordered]@{
+            '$schema'        = 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
+            'contentVersion' = '1.0.0.0'
+        }
+        $parameters = $paramHashTable
+        $templateBase['parameters'] = $parameters
+        $tempTemplate = ConvertTo-Json -InputObject $templateBase -Depth 100
+        Out-File -InputObject $tempTemplate -FilePath "$tempPath\tempfile.json"
+        $file = Get-ChildItem -Path "$tempPath\tempfile.json"
+
+        if ($file) {
+            $BicepObject = [Bicep.Decompiler.TemplateDecompiler]::DecompileFileWithModules($ResourceProvider, $FileResolver, $file.FullName)
+            foreach ($BicepFile in $BicepObject.Item2.Keys) {
+                $bicepData = $BicepObject.Item2[$BicepFile]
+            }
+            $bicepOutput = $bicepData.Replace("var temp = ", "")
+            Write-Host $bicepOutput
+        }
+        Remove-Item $file
+    }
+}

--- a/Source/Public/Convert-BicepParamsToDecoratorStyle.ps1
+++ b/Source/Public/Convert-BicepParamsToDecoratorStyle.ps1
@@ -15,8 +15,11 @@ function Convert-BicepParamsToDecoratorStyle {
 
     process {
         $armHashTable = Build-Bicep -Path $Path -AsHashtable -IgnoreDiagnostics
+        if (!$armHashTable) {
+            Write-Error "Invalid bicep file provided as input. Fix all build errors and try again."
+        }
         $paramHashTable = $armHashTable.parameters
-
+        
         $parameters = [ordered]@{}
         $templateBase = [ordered]@{
             '$schema'        = 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
@@ -33,8 +36,7 @@ function Convert-BicepParamsToDecoratorStyle {
             foreach ($BicepFile in $BicepObject.Item2.Keys) {
                 $bicepData = $BicepObject.Item2[$BicepFile]
             }
-            $bicepOutput = $bicepData.Replace("var temp = ", "")
-            Write-Host $bicepOutput
+            Write-Host $bicepData
         }
         Remove-Item $file
     }

--- a/Source/Public/Convert-BicepParamsToDecoratorStyle.ps1
+++ b/Source/Public/Convert-BicepParamsToDecoratorStyle.ps1
@@ -16,7 +16,7 @@ function Convert-BicepParamsToDecoratorStyle {
     }
 
     process {
-        if (!($IsWindows)) {
+        if ((!$IsWindows) -and $ToClipboard.IsPresent) {
             Write-Error -Message "The -ToClipboard switch is only supported on Windows systems."
             break
         }

--- a/Source/Public/Convert-BicepParamsToDecoratorStyle.ps1
+++ b/Source/Public/Convert-BicepParamsToDecoratorStyle.ps1
@@ -11,7 +11,7 @@ function Convert-BicepParamsToDecoratorStyle {
 
     begin {
         $FileResolver = [Bicep.Core.FileSystem.FileResolver]::new()
-        $ResourceProvider = [Bicep.Core.TypeSystem.Az.AzResourceTypeProvider]::new()
+        $ResourceProvider = [Bicep.Core.TypeSystem.Az.AzResourceTypeProvider]::CreateWithAzTypes()
         $tempPath = [System.Io.Path]::GetTempPath()
     }
 

--- a/Source/Public/Convert-BicepParamsToDecoratorStyle.ps1
+++ b/Source/Public/Convert-BicepParamsToDecoratorStyle.ps1
@@ -14,7 +14,7 @@ function Convert-BicepParamsToDecoratorStyle {
     }
 
     process {
-        $armHashTable = Build-Bicep -Path $Path -AsHashtable -IgnoreWarnings
+        $armHashTable = Build-Bicep -Path $Path -AsHashtable -IgnoreDiagnostics
         $paramHashTable = $armHashTable.parameters
 
         $parameters = [ordered]@{}

--- a/Source/Public/Convert-BicepParamsToDecoratorStyle.ps1
+++ b/Source/Public/Convert-BicepParamsToDecoratorStyle.ps1
@@ -4,7 +4,9 @@ function Convert-BicepParamsToDecoratorStyle {
         [Parameter(Mandatory,
             ParameterSetName = 'Default')]
         [ValidateNotNullOrEmpty()]
-        [string]$Path
+        [string]$Path,
+        [Parameter(ParameterSetName = 'Default')]
+        [switch]$ToClipboard
     )
 
     begin {
@@ -36,7 +38,13 @@ function Convert-BicepParamsToDecoratorStyle {
             foreach ($BicepFile in $BicepObject.Item2.Keys) {
                 $bicepData = $BicepObject.Item2[$BicepFile]
             }
-            Write-Host $bicepData
+            if ($ToClipboard.IsPresent) {
+                Set-Clipboard $bicepData
+                Write-Host "Decorator style params saved to clipboard"
+            }
+            else {
+                Write-Host $bicepData
+            }
         }
         Remove-Item $file
     }

--- a/Source/Public/Convert-BicepParamsToDecoratorStyle.ps1
+++ b/Source/Public/Convert-BicepParamsToDecoratorStyle.ps1
@@ -39,7 +39,13 @@ function Convert-BicepParamsToDecoratorStyle {
                 $bicepData = $BicepObject.Item2[$BicepFile]
             }
             if ($ToClipboard.IsPresent) {
-                Set-Clipboard $bicepData
+                if (!$IsWindows) {
+                    $xclip = (Get-Command xclip -ErrorAction SilentlyContinue)
+                    if (!$xclip) {
+                        Write-Error "xclip is required to save parameters to clipboard." -ErrorAction Stop
+                    }
+                }
+                Set-Clipboard -Value $bicepData
                 Write-Host "Decorator style params saved to clipboard"
             }
             else {

--- a/Source/Public/Convert-BicepParamsToDecoratorStyle.ps1
+++ b/Source/Public/Convert-BicepParamsToDecoratorStyle.ps1
@@ -16,6 +16,11 @@ function Convert-BicepParamsToDecoratorStyle {
     }
 
     process {
+        if (!($IsWindows)) {
+            Write-Error -Message "The -ToClipboard switch is only supported on Windows systems."
+            break
+        }
+        
         $armHashTable = Build-Bicep -Path $Path -AsHashtable -IgnoreDiagnostics
         if (!$armHashTable) {
             Write-Error "Invalid bicep file provided as input. Fix all build errors and try again."
@@ -38,13 +43,7 @@ function Convert-BicepParamsToDecoratorStyle {
             foreach ($BicepFile in $BicepObject.Item2.Keys) {
                 $bicepData = $BicepObject.Item2[$BicepFile]
             }
-            if ($ToClipboard.IsPresent) {
-                if (!$IsWindows) {
-                    $xclip = (Get-Command xclip -ErrorAction SilentlyContinue)
-                    if (!$xclip) {
-                        Write-Error "xclip is required to save parameters to clipboard." -ErrorAction Stop
-                    }
-                }
+            if ($ToClipboard.IsPresent) {                
                 Set-Clipboard -Value $bicepData
                 Write-Host "Decorator style params saved to clipboard"
             }

--- a/Source/en-US/Bicep-help.xml
+++ b/Source/en-US/Bicep-help.xml
@@ -459,6 +459,17 @@ New-AzResourceGroupDeployment -ResourceGroupName vnet-rg -TemplateObject $Templa
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>ToClipboard</maml:name>
+          <maml:description>
+            <maml:para>Saves the converted params to the clipboard.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
@@ -473,6 +484,18 @@ New-AzResourceGroupDeployment -ResourceGroupName vnet-rg -TemplateObject $Templa
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>ToClipboard</maml:name>
+        <maml:description>
+          <maml:para>Saves the converted params to the clipboard.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
     </command:parameters>
     <command:inputTypes>
@@ -506,6 +529,13 @@ New-AzResourceGroupDeployment -ResourceGroupName vnet-rg -TemplateObject $Templa
         <dev:code>Convert-BicepParamsToDecoratorStyle -Path .\VirtualHubVPNGateway.bicep</dev:code>
         <dev:remarks>
           <maml:para>This example takes a bicep file as input and converts all parameters to decorator style parameters and outputs the result.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Example 2: Convert parameters from one bicep file to decorator style parameters and save to clipboard</maml:title>
+        <dev:code>Convert-BicepParamsToDecoratorStyle -Path .\VirtualHubVPNGateway.bicep -ToClipboard</dev:code>
+        <dev:remarks>
+          <maml:para>This example takes a bicep file as input and converts all parameters to decorator style parameters saves the result to the clipboard.</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>

--- a/Source/en-US/Bicep-help.xml
+++ b/Source/en-US/Bicep-help.xml
@@ -467,7 +467,7 @@ New-AzResourceGroupDeployment -ResourceGroupName vnet-rg -TemplateObject $Templa
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-          <maml:name>ToClipboard</maml:name>
+          <maml:name>ToClipboard  (Windows only)</maml:name>
           <maml:description>
             <maml:para>Saves the converted params to the clipboard.</maml:para>
           </maml:description>
@@ -493,7 +493,7 @@ New-AzResourceGroupDeployment -ResourceGroupName vnet-rg -TemplateObject $Templa
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-        <maml:name>ToClipboard</maml:name>
+        <maml:name>ToClipboard  (Windows only)</maml:name>
         <maml:description>
           <maml:para>Saves the converted params to the clipboard.</maml:para>
         </maml:description>

--- a/Source/en-US/Bicep-help.xml
+++ b/Source/en-US/Bicep-help.xml
@@ -89,6 +89,17 @@ Any error or warning from bicep will be written to the information stream. To sa
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>IgnoreDiagnostics</maml:name>
+          <maml:description>
+            <maml:para>Ignores all build warnings and errors.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
       <command:syntaxItem>
         <maml:name>Build-Bicep</maml:name>
@@ -103,18 +114,6 @@ Any error or warning from bicep will be written to the information stream. To sa
             <maml:uri />
           </dev:type>
           <dev:defaultValue>$pwd.path</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="3" aliases="none">
-          <maml:name>OutputDirectory</maml:name>
-          <maml:description>
-            <maml:para>Specfies the target directory where the compiled files should be created</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>ExcludeFile</maml:name>
@@ -161,6 +160,17 @@ Any error or warning from bicep will be written to the information stream. To sa
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>IgnoreDiagnostics</maml:name>
+          <maml:description>
+            <maml:para>Ignores all build warnings and errors.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
       <command:syntaxItem>
         <maml:name>Build-Bicep</maml:name>
@@ -175,18 +185,6 @@ Any error or warning from bicep will be written to the information stream. To sa
             <maml:uri />
           </dev:type>
           <dev:defaultValue>$pwd.path</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="3" aliases="none">
-          <maml:name>OutputDirectory</maml:name>
-          <maml:description>
-            <maml:para>Specfies the target directory where the compiled files should be created</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>ExcludeFile</maml:name>
@@ -226,6 +224,17 @@ Any error or warning from bicep will be written to the information stream. To sa
           <maml:name>WhatIf</maml:name>
           <maml:description>
             <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>IgnoreDiagnostics</maml:name>
+          <maml:description>
+            <maml:para>Ignores all build warnings and errors.</maml:para>
           </maml:description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -332,6 +341,18 @@ Any error or warning from bicep will be written to the information stream. To sa
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>IgnoreDiagnostics</maml:name>
+        <maml:description>
+          <maml:para>Ignores all build warnings and errors.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
     </command:parameters>
     <command:inputTypes />
     <command:returnValues />
@@ -399,6 +420,92 @@ $Diagnostics | Where-Object Tags -eq 'Warning'</dev:code>
 New-AzResourceGroupDeployment -ResourceGroupName vnet-rg -TemplateObject $Template</dev:code>
         <dev:remarks>
           <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Example 8: Compile a .bicep and ignore all build warnings and errors</maml:title>
+        <dev:code>Build-Bicep -Path '.\vnet.bicep' -IgnoreDiagnostics</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>Convert-BicepParamsToDecoratorStyle</command:name>
+      <command:verb>Convert</command:verb>
+      <command:noun>BicepParamsToDecoratorStyle</command:noun>
+      <maml:description>
+        <maml:para>Convert Bicep parameters from v0.1-0.2 style to decorator style.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>This command convert Bicep parameters from v0.1-0.2 style to decorator style using a bicep file as input.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Convert-BicepParamsToDecoratorStyle</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Path</maml:name>
+          <maml:description>
+            <maml:para>Specfies the path to the file with parameters to convert</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>Path</maml:name>
+        <maml:description>
+          <maml:para>Specfies the path to the file with parameters to convert</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Example 1: Convert parameters from one bicep file to decorator style parameters</maml:title>
+        <dev:code>Convert-BicepParamsToDecoratorStyle -Path .\VirtualHubVPNGateway.bicep</dev:code>
+        <dev:remarks>
+          <maml:para>This example takes a bicep file as input and converts all parameters to decorator style parameters and outputs the result.</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>


### PR DESCRIPTION
Added new command `Convert-BicepParamsToDecoratorStyle` mentioned in #133 

- New command added `Convert-BicepParamsToDecoratorStyle`
- Added an `-IgnoreDiagnostics` switch to `ParseBicep` and `BuildBicep` to support the new command without outputting diagnostics
- Updated help file
- Fixed docs for `Build-Bicep` and created docs for `Convert-BicepParamsToDecoratorStyle`

How it works:

**params.bicep**
```bicep
param location string = resourceGroup().location
param sku string {
  default: 'Premium'
  allowed: [
    'Standard'
    'Premium'
  ]
}
param publicipcount int {
  default: 1
  metadata: {
    description: 'Specifies the number of public IPs to allocate to the firewall when deploying Azure Firewall'
  }
}
param psk string {
   secure: true
}
```
Convert the parameters from input `.bicep` file to decorator style:
```powershell
Convert-BicepParamsToDecoratorStyle -Path .\params.bicep
param location string = resourceGroup().location

@allowed([
  'Standard'
  'Premium'
])
param sku string = 'Premium'

@description('Specifies the number of public IPs to allocate to the firewall when deploying Azure Firewall')
param publicipcount int = 1

@secure()
param psk string
````

or using the `-ToClipboard` switch:
```powershell
Convert-BicepParamsToDecoratorStyle -Path .\params.bicep -ToClipboard
Decorator style params saved to clipboard
```


