### PR TITLE
Added options for generate parameter file

### DIFF
--- a/Docs/Help/Build-Bicep.md
+++ b/Docs/Help/Build-Bicep.md
@@ -13,24 +13,26 @@ Builds one or more .bicep files.
 ## SYNTAX
 
 ### Default (Default)
-```Powershell
-Build-Bicep [[-Path] <String>] [[-OutputDirectory] <String>] [-ExcludeFile <String[]>] [-GenerateParameterFile]
- [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
+Build-Bicep [[-Path] <String>] [[-OutputDirectory] <String>] [-ExcludeFile <String[]>]
+ [-GenerateParameterFile <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
 ### OutputPath
-```Powershell
-Build-Bicep [[-Path] <string>] [[-OutputPath] <string>] [-ExcludeFile <string[]>] [-GenerateParameterFile] [-WhatIf] [-Confirm] [<CommonParameters>]   
 ```
+Build-Bicep [[-Path] <String>] [-OutputPath <String>] [-ExcludeFile <String[]>]
+ [-GenerateParameterFile <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
 ### AsHashtable
-```Powershell
-Build-Bicep [[-Path] <String>] [[-OutputDirectory] <String>] [-ExcludeFile <String[]>] [-AsHashtable] [-WhatIf]
- [-Confirm] [<CommonParameters>]
+```
+Build-Bicep [[-Path] <String>] [-ExcludeFile <String[]>] [-AsHashtable] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ### AsString
-```Powershell
-Build-Bicep [[-Path] <String>] [[-OutputDirectory] <String>] [-ExcludeFile <String[]>] [-AsString] [-WhatIf]
- [-Confirm] [<CommonParameters>]
+```
+Build-Bicep [[-Path] <String>] [-ExcludeFile <String[]>] [-AsString] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -70,9 +72,9 @@ Build-Bicep -Path 'c:\bicep\modules\' -ExcludeFile vnet.bicep
 Build-Bicep -Path '.\vnet.bicep' -AsString
 ```
 
-### Example 6: Compile a .bicep files in the working directory and generate a parameter files
+### Example 6: Compile a .bicep files in the working directory and generate a parameter file with all parameters
 ```powershell
-Build-Bicep -Path '.\vnet.bicep' -GenerateParameterFile
+Build-Bicep -Path '.\vnet.bicep' -GenerateParameterFile All
 ```
 
 ### Example 7: Compile a .bicep files in the working directory and store diagnostic messages from bicep in a variable.
@@ -91,11 +93,11 @@ Then outputs first all Errors then all Warnings.
 $Template=Build-Bicep -Path '.\vnet.bicep' -AsHashtable
 New-AzResourceGroupDeployment -ResourceGroupName vnet-rg -TemplateObject $Template
 ```
+
 ### Example 9: Compiles single bicep file and saves the output as the specified file path.
 ```powershell
 Build-Bicep -Path 'c:\bicep\modules\vnet.bicep' -OutputPath 'c:\armtemplates\newvnet.json'
 ```
-
 
 ## PARAMETERS
 
@@ -119,7 +121,7 @@ Specfies the target directory where the compiled files should be created
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: Default
 Aliases:
 
 Required: False
@@ -145,11 +147,11 @@ Accept wildcard characters: False
 ```
 
 ### -GenerateParameterFile
-The -GenerateParameterFile switch generates a ARM Template parameter file for the compiled template
+The -GenerateParameterFile parameter generates a ARM Template parameter file for the compiled template
 
 ```yaml
-Type: SwitchParameter
-Parameter Sets: Default
+Type: String
+Parameter Sets: Default, OutputPath
 Aliases:
 
 Required: False
@@ -211,6 +213,21 @@ Shows what would happen if the cmdlet runs. The cmdlet is not run.
 Type: SwitchParameter
 Parameter Sets: (All)
 Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OutputPath
+{{ Fill OutputPath Description }}
+
+```yaml
+Type: String
+Parameter Sets: OutputPath
+Aliases:
 
 Required: False
 Position: Named

--- a/Docs/Help/Build-Bicep.md
+++ b/Docs/Help/Build-Bicep.md
@@ -15,13 +15,13 @@ Builds one or more .bicep files.
 ### Default (Default)
 ```
 Build-Bicep [[-Path] <String>] [[-OutputDirectory] <String>] [-ExcludeFile <String[]>]
- [-GenerateParameterFile <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-GenerateAllParametersFile] [-GenerateRequiredParametersFile] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### OutputPath
 ```
-Build-Bicep [[-Path] <String>] [-OutputPath <String>] [-ExcludeFile <String[]>]
- [-GenerateParameterFile <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Build-Bicep [[-Path] <String>] [-OutputPath <String>] [-ExcludeFile <String[]>] [-GenerateAllParametersFile]
+ [-GenerateRequiredParametersFile] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### AsHashtable
@@ -74,7 +74,7 @@ Build-Bicep -Path '.\vnet.bicep' -AsString
 
 ### Example 6: Compile a .bicep files in the working directory and generate a parameter file with all parameters
 ```powershell
-Build-Bicep -Path '.\vnet.bicep' -GenerateParameterFile All
+Build-Bicep -Path '.\vnet.bicep' -GenerateAllParametersFile
 ```
 
 ### Example 7: Compile a .bicep files in the working directory and store diagnostic messages from bicep in a variable.
@@ -146,21 +146,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -GenerateParameterFile
-The -GenerateParameterFile parameter generates a ARM Template parameter file for the compiled template
-
-```yaml
-Type: String
-Parameter Sets: Default, OutputPath
-Aliases:
-
-Required: False
-Position: Named
-Default value: False
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -AsString
 The -AsString prints all output as a string instead of corresponding files.
 
@@ -227,6 +212,36 @@ Accept wildcard characters: False
 ```yaml
 Type: String
 Parameter Sets: OutputPath
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -GenerateAllParametersFile
+Generate an ARM template parameter file with all parameters from the bicep file.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Default, OutputPath
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -GenerateRequiredParametersFile
+Generate an ARM template parameter file with the required parameters from the bicep file.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Default, OutputPath
 Aliases:
 
 Required: False

--- a/Docs/Help/Build-Bicep.md
+++ b/Docs/Help/Build-Bicep.md
@@ -207,7 +207,7 @@ Accept wildcard characters: False
 ```
 
 ### -OutputPath
-{{ Fill OutputPath Description }}
+Specify the filename of the generated ARM template.
 
 ```yaml
 Type: String

--- a/Docs/Help/New-BicepParameterFile.md
+++ b/Docs/Help/New-BicepParameterFile.md
@@ -13,8 +13,9 @@ Creates an ARM Template parameter file based on a bicep file.
 
 ## SYNTAX
 
-```powershell
-New-BicepParameterFile [-Path] <String> [[-OutputDirectory] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+New-BicepParameterFile [-Path] <String> [-Type <String>] [[-OutputDirectory] <String>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -23,18 +24,27 @@ Creates an ARM Template parameter file based on a bicep file. The parameter file
 
 ## EXAMPLES
 
-### Example 1
+### Example 1: Generate an ARM Template parameter file for a bicep file
 
 ```powershell
-PS C:\> New-BicepParameterFile -Path 'AzureFirewall.bicep'
+New-BicepParameterFile -Path 'AzureFirewall.bicep'
 ```
 
 Creates a parameter file called AzureFirewall.parameters.json in the same directory as the bicep file.
 
-### Example 2
+### Example 2: Generate an ARM Template parameter file for a bicep file with only required parameters
 
 ```powershell
-PS C:\> New-BicepParameterFile -Path 'AzureFirewall.bicep' -OutputDirectory 'd:\myfolder\'
+New-BicepParameterFile -Path 'AzureFirewall.bicep' -Type Required
+```
+
+Creates a parameter file called AzureFirewall.parameters.json in the same directory as the bicep file.
+
+
+### Example 3: Creates a parameter file in the specified directory
+
+```powershell
+New-BicepParameterFile -Path 'AzureFirewall.bicep' -OutputDirectory 'd:\myfolder\'
 ```
 
 Creates a parameter file in the specified directory.
@@ -106,8 +116,22 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### CommonParameters
+### -Type
+{{ Fill Type Description }}
 
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS

--- a/Docs/Help/New-BicepParameterFile.md
+++ b/Docs/Help/New-BicepParameterFile.md
@@ -14,8 +14,8 @@ Creates an ARM Template parameter file based on a bicep file.
 ## SYNTAX
 
 ```
-New-BicepParameterFile [-Path] <String> [-Type <String>] [[-OutputDirectory] <String>] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+New-BicepParameterFile [-Path] <String> [-Parameters <String>] [[-OutputDirectory] <String>] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -32,14 +32,13 @@ New-BicepParameterFile -Path 'AzureFirewall.bicep'
 
 Creates a parameter file called AzureFirewall.parameters.json in the same directory as the bicep file.
 
-### Example 2: Generate an ARM Template parameter file for a bicep file with only required parameters
+### Example 2: Generate an ARM Template parameter file for a bicep file with all parameters from the bicep file
 
 ```powershell
-New-BicepParameterFile -Path 'AzureFirewall.bicep' -Type Required
+New-BicepParameterFile -Path 'AzureFirewall.bicep' -Parameters All
 ```
 
 Creates a parameter file called AzureFirewall.parameters.json in the same directory as the bicep file.
-
 
 ### Example 3: Creates a parameter file in the specified directory
 
@@ -116,8 +115,8 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Type
-{{ Fill Type Description }}
+### -Parameters
+Specify which parameters should be exported to the parameter file.
 
 ```yaml
 Type: String

--- a/Source/Private/GenerateParameterFile.ps1
+++ b/Source/Private/GenerateParameterFile.ps1
@@ -1,20 +1,24 @@
 function GenerateParameterFile {
-    [CmdletBinding(DefaultParameterSetName='FromFile',
-                   SupportsShouldProcess)]
+    [CmdletBinding(DefaultParameterSetName = 'FromFile',
+        SupportsShouldProcess)]
     param (
         [Parameter(Mandatory,
-                   ParameterSetName = 'FromFile')]
+            ParameterSetName = 'FromFile')]
         [object]$File,
 
         [Parameter(Mandatory,
-                   ParameterSetName = 'FromContent')]
+            ParameterSetName = 'FromContent')]
         [ValidateNotNullOrEmpty()]
         [string]$Content,
 
         [Parameter(Mandatory,
-                   ParameterSetName = 'FromContent')]
+            ParameterSetName = 'FromContent')]
         [ValidateNotNullOrEmpty()]
-        [string]$DestinationPath
+        [string]$DestinationPath,
+
+        [Parameter(ParameterSetName = 'FromFile')]
+        [Parameter(ParameterSetName = 'FromContent')]
+        [string]$Type
     )
 
     if ($PSCmdlet.ParameterSetName -eq 'FromFile') {
@@ -33,6 +37,7 @@ function GenerateParameterFile {
     $parameters = [ordered]@{}
     foreach ($parameterName in $parameterNames) {
         $ParameterObject = $ARMTemplate.Parameters.$ParameterName
+        if (($Type -eq "Required" -and $null -eq $ParameterObject.defaultValue) -or ($Type -eq "All")) {
         if ($null -eq $ParameterObject.defaultValue) {                               
             if ($ParameterObject.type -eq 'Array') {
                 $defaultValue = @()
@@ -53,8 +58,9 @@ function GenerateParameterFile {
         else {
             $defaultValue = $ParameterObject.defaultValue
         }
-        $parameters[$parameterName] = @{                                
-            value = $defaultValue
+            $parameters[$parameterName] = @{                                
+                value = $defaultValue
+            }
         }                       
     }
     $parameterBase['parameters'] = $parameters

--- a/Source/Private/GenerateParameterFile.ps1
+++ b/Source/Private/GenerateParameterFile.ps1
@@ -18,7 +18,7 @@ function GenerateParameterFile {
 
         [Parameter(ParameterSetName = 'FromFile')]
         [Parameter(ParameterSetName = 'FromContent')]
-        [string]$Type
+        [string]$Parameters
     )
 
     if ($PSCmdlet.ParameterSetName -eq 'FromFile') {
@@ -34,10 +34,10 @@ function GenerateParameterFile {
         'contentVersion' = '1.0.0.0'
     }
     $parameterNames = $ARMTemplate.Parameters.psobject.Properties.Name
-    $parameters = [ordered]@{}
+    $parameterHash = [ordered]@{}
     foreach ($parameterName in $parameterNames) {
         $ParameterObject = $ARMTemplate.Parameters.$ParameterName
-        if (($Type -eq "Required" -and $null -eq $ParameterObject.defaultValue) -or ($Type -eq "All")) {
+        if (($Parameters -eq "Required" -and $null -eq $ParameterObject.defaultValue) -or ($Parameters -eq "All")) {
         if ($null -eq $ParameterObject.defaultValue) {                               
             if ($ParameterObject.type -eq 'Array') {
                 $defaultValue = @()
@@ -58,12 +58,12 @@ function GenerateParameterFile {
         else {
             $defaultValue = $ParameterObject.defaultValue
         }
-            $parameters[$parameterName] = @{                                
+            $parameterHash[$parameterName] = @{                                
                 value = $defaultValue
             }
         }                       
     }
-    $parameterBase['parameters'] = $parameters
+    $parameterBase['parameters'] = $parameterHash
     $ConvertedToJson = ConvertTo-Json -InputObject $parameterBase -Depth 100
     
     switch ($PSCmdlet.ParameterSetName) {

--- a/Source/Public/Build-Bicep.ps1
+++ b/Source/Public/Build-Bicep.ps1
@@ -30,8 +30,11 @@ function Build-Bicep {
 
         [Parameter(ParameterSetName = 'Default')]
         [Parameter(ParameterSetName = 'OutputPath')]
-        [ValidateSet("All", "Required", ErrorMessage="Allowed values for GenerateParameterFile are All or Required")]
-        [string]$GenerateParameterFile,
+        [switch]$GenerateAllParametersFile,
+
+        [Parameter(ParameterSetName = 'Default')]
+        [Parameter(ParameterSetName = 'OutputPath')]
+        [switch]$GenerateRequiredParametersFile,
 
         [Parameter(ParameterSetName = 'AsString')]
         [switch]$AsString,
@@ -93,8 +96,19 @@ function Build-Bicep {
                                 $ParameterFilePath = $file.FullName -replace '\.bicep', '.parameters.json'
                             }
                             $null = Out-File -Path $OutputFilePath -InputObject $ARMTemplate -Encoding utf8 -WhatIf:$WhatIfPreference
-                            if ($GenerateParameterFile) {
-                                GenerateParameterFile -Content $ARMTemplate -DestinationPath $ParameterFilePath -Type $GenerateParameterFile -WhatIf:$WhatIfPreference
+                            if ($GenerateRequiredParametersFile.IsPresent -and $GenerateAllParametersFile.IsPresent) {
+                                $parameterType = 'All'                                    
+                                Write-Warning "Both -GenerateAllParametersFile and -GenerateRequiredParametersFile is present. A parameter file with all parameters will be generated."
+                            }
+                            elseif ($GenerateRequiredParametersFile.IsPresent) {
+                                $parameterType = 'Required'
+                            }
+                            elseif ($GenerateAllParametersFile.IsPresent) {
+                                $parameterType = 'All'
+                            }
+
+                            if ($GenerateAllParametersFile.IsPresent -or $GenerateRequiredParametersFile.IsPresent) {                                
+                                GenerateParameterFile -Content $ARMTemplate -DestinationPath $ParameterFilePath -Parameters $parameterType -WhatIf:$WhatIfPreference
                             }
                         }
                     }

--- a/Source/Public/Build-Bicep.ps1
+++ b/Source/Public/Build-Bicep.ps1
@@ -30,7 +30,8 @@ function Build-Bicep {
 
         [Parameter(ParameterSetName = 'Default')]
         [Parameter(ParameterSetName = 'OutputPath')]
-        [switch]$GenerateParameterFile,
+        [ValidateSet("All", "Required", ErrorMessage="Allowed values for GenerateParameterFile are All or Required")]
+        [string]$GenerateParameterFile,
 
         [Parameter(ParameterSetName = 'AsString')]
         [switch]$AsString,
@@ -92,8 +93,8 @@ function Build-Bicep {
                                 $ParameterFilePath = $file.FullName -replace '\.bicep', '.parameters.json'
                             }
                             $null = Out-File -Path $OutputFilePath -InputObject $ARMTemplate -Encoding utf8 -WhatIf:$WhatIfPreference
-                            if ($GenerateParameterFile.IsPresent) {
-                                GenerateParameterFile -Content $ARMTemplate -DestinationPath $ParameterFilePath -WhatIf:$WhatIfPreference
+                            if ($GenerateParameterFile) {
+                                GenerateParameterFile -Content $ARMTemplate -DestinationPath $ParameterFilePath -Type $GenerateParameterFile -WhatIf:$WhatIfPreference
                             }
                         }
                     }

--- a/Source/Public/New-BicepParameterFile.ps1
+++ b/Source/Public/New-BicepParameterFile.ps1
@@ -7,7 +7,7 @@ function New-BicepParameterFile {
         [Parameter(Position = 2)]
         [ValidateNotNullOrEmpty()]
         [ValidateSet("All", "Required")]
-        [string]$Type,        
+        [string]$Parameters,        
 
         [Parameter(Position = 3)]
         [ValidateNotNullOrEmpty()]
@@ -39,10 +39,10 @@ function New-BicepParameterFile {
             else {
                 $OutputFilePath = $File.FullName -replace '\.bicep','.parameters.json'
             }
-            if (!$PSBoundParameters.ContainsKey('Type')){
-                $Type='All'
+            if (!$PSBoundParameters.ContainsKey('Parameters')){
+                $Parameters='Required'
             }
-             GenerateParameterFile -Content $ARMTemplate -Type $Type -DestinationPath $OutputFilePath -WhatIf:$WhatIfPreference
+             GenerateParameterFile -Content $ARMTemplate -Parameters $Parameters -DestinationPath $OutputFilePath -WhatIf:$WhatIfPreference
         }
         else {
             Write-Error "No bicep file named $Path was found!"

--- a/Source/Public/New-BicepParameterFile.ps1
+++ b/Source/Public/New-BicepParameterFile.ps1
@@ -6,6 +6,11 @@ function New-BicepParameterFile {
 
         [Parameter(Position = 2)]
         [ValidateNotNullOrEmpty()]
+        [ValidateSet("All", "Required")]
+        [string]$Type,        
+
+        [Parameter(Position = 3)]
+        [ValidateNotNullOrEmpty()]
         [string]$OutputDirectory
     )
 
@@ -34,8 +39,10 @@ function New-BicepParameterFile {
             else {
                 $OutputFilePath = $File.FullName -replace '\.bicep','.parameters.json'
             }
-
-            GenerateParameterFile -Content $ARMTemplate -DestinationPath $OutputFilePath -WhatIf:$WhatIfPreference
+            if (!$PSBoundParameters.ContainsKey('Type')){
+                $Type='All'
+            }
+             GenerateParameterFile -Content $ARMTemplate -Type $Type -DestinationPath $OutputFilePath -WhatIf:$WhatIfPreference
         }
         else {
             Write-Error "No bicep file named $Path was found!"

--- a/Source/en-US/Bicep-help.xml
+++ b/Source/en-US/Bicep-help.xml
@@ -59,10 +59,11 @@ Any error or warning from bicep will be written to the information stream. To sa
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>GenerateParameterFile</maml:name>
           <maml:description>
-            <maml:para>The -GenerateParameterFile switch generates a ARM Template parameter file for the compiled template</maml:para>
+            <maml:para>The -GenerateParameterFile parameter generates a ARM Template parameter file for the compiled template</maml:para>
           </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
-            <maml:name>SwitchParameter</maml:name>
+            <maml:name>String</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
@@ -104,10 +105,56 @@ Any error or warning from bicep will be written to the information stream. To sa
           </dev:type>
           <dev:defaultValue>$pwd.path</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="3" aliases="none">
-          <maml:name>OutputDirectory</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>ExcludeFile</maml:name>
           <maml:description>
-            <maml:para>Specfies the target directory where the compiled files should be created</maml:para>
+            <maml:para>Specifies a .bicep file to exclude from compilation</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>GenerateParameterFile</maml:name>
+          <maml:description>
+            <maml:para>The -GenerateParameterFile parameter generates a ARM Template parameter file for the compiled template</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+          <maml:name>Confirm</maml:name>
+          <maml:description>
+            <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+          <maml:name>WhatIf</maml:name>
+          <maml:description>
+            <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>OutputPath</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill OutputPath Description }}</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -115,6 +162,21 @@ Any error or warning from bicep will be written to the information stream. To sa
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Build-Bicep</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="2" aliases="none">
+          <maml:name>Path</maml:name>
+          <maml:description>
+            <maml:para>Specfies the path to the directory or file that should be compiled</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>$pwd.path</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>ExcludeFile</maml:name>
@@ -175,18 +237,6 @@ Any error or warning from bicep will be written to the information stream. To sa
             <maml:uri />
           </dev:type>
           <dev:defaultValue>$pwd.path</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="3" aliases="none">
-          <maml:name>OutputDirectory</maml:name>
-          <maml:description>
-            <maml:para>Specfies the target directory where the compiled files should be created</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>ExcludeFile</maml:name>
@@ -275,11 +325,11 @@ Any error or warning from bicep will be written to the information stream. To sa
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>GenerateParameterFile</maml:name>
         <maml:description>
-          <maml:para>The -GenerateParameterFile switch generates a ARM Template parameter file for the compiled template</maml:para>
+          <maml:para>The -GenerateParameterFile parameter generates a ARM Template parameter file for the compiled template</maml:para>
         </maml:description>
-        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
-          <maml:name>SwitchParameter</maml:name>
+          <maml:name>String</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
@@ -332,6 +382,18 @@ Any error or warning from bicep will be written to the information stream. To sa
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>OutputPath</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill OutputPath Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
     </command:parameters>
     <command:inputTypes />
     <command:returnValues />
@@ -377,8 +439,8 @@ Any error or warning from bicep will be written to the information stream. To sa
         </dev:remarks>
       </command:example>
       <command:example>
-        <maml:title>Example 6: Compile a .bicep files in the working directory and generate a parameter files</maml:title>
-        <dev:code>Build-Bicep -Path '.\vnet.bicep' -GenerateParameterFile</dev:code>
+        <maml:title>Example 6: Compile a .bicep files in the working directory and generate a parameter file with all parameters</maml:title>
+        <dev:code>Build-Bicep -Path '.\vnet.bicep' -GenerateParameterFile All</dev:code>
         <dev:remarks>
           <maml:para></maml:para>
         </dev:remarks>
@@ -1077,6 +1139,18 @@ Convert-JsonToBicep -String $json</dev:code>
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Type</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill Type Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
@@ -1128,6 +1202,18 @@ Convert-JsonToBicep -String $json</dev:code>
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>Type</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill Type Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
     </command:parameters>
     <command:inputTypes>
       <command:inputType>
@@ -1156,15 +1242,22 @@ Convert-JsonToBicep -String $json</dev:code>
     </maml:alertSet>
     <command:examples>
       <command:example>
-        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
-        <dev:code>PS C:\&gt; New-BicepParameterFile -Path 'AzureFirewall.bicep'</dev:code>
+        <maml:title>Example 1: Generate an ARM Template parameter file for a bicep file</maml:title>
+        <dev:code>New-BicepParameterFile -Path 'AzureFirewall.bicep'</dev:code>
         <dev:remarks>
           <maml:para>Creates a parameter file called AzureFirewall.parameters.json in the same directory as the bicep file.</maml:para>
         </dev:remarks>
       </command:example>
       <command:example>
-        <maml:title>-------------------------- Example 2 --------------------------</maml:title>
-        <dev:code>PS C:\&gt; New-BicepParameterFile -Path 'AzureFirewall.bicep' -OutputDirectory 'd:\myfolder\'</dev:code>
+        <maml:title>Example 2: Generate an ARM Template parameter file for a bicep file with only required parameters</maml:title>
+        <dev:code>New-BicepParameterFile -Path 'AzureFirewall.bicep' -Type Required</dev:code>
+        <dev:remarks>
+          <maml:para>Creates a parameter file called AzureFirewall.parameters.json in the same directory as the bicep file.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Example 3: Creates a parameter file in the specified directory</maml:title>
+        <dev:code>New-BicepParameterFile -Path 'AzureFirewall.bicep' -OutputDirectory 'd:\myfolder\'</dev:code>
         <dev:remarks>
           <maml:para>Creates a parameter file in the specified directory.</maml:para>
         </dev:remarks>

--- a/Source/en-US/Bicep-help.xml
+++ b/Source/en-US/Bicep-help.xml
@@ -56,79 +56,6 @@ Any error or warning from bicep will be written to the information stream. To sa
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-          <maml:name>GenerateParameterFile</maml:name>
-          <maml:description>
-            <maml:para>The -GenerateParameterFile parameter generates a ARM Template parameter file for the compiled template</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>False</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
-          <maml:name>Confirm</maml:name>
-          <maml:description>
-            <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
-          </maml:description>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>False</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
-          <maml:name>WhatIf</maml:name>
-          <maml:description>
-            <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
-          </maml:description>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>False</dev:defaultValue>
-        </command:parameter>
-      </command:syntaxItem>
-      <command:syntaxItem>
-        <maml:name>Build-Bicep</maml:name>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="2" aliases="none">
-          <maml:name>Path</maml:name>
-          <maml:description>
-            <maml:para>Specfies the path to the directory or file that should be compiled</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>$pwd.path</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-          <maml:name>ExcludeFile</maml:name>
-          <maml:description>
-            <maml:para>Specifies a .bicep file to exclude from compilation</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
-          <dev:type>
-            <maml:name>String[]</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-          <maml:name>GenerateParameterFile</maml:name>
-          <maml:description>
-            <maml:para>The -GenerateParameterFile parameter generates a ARM Template parameter file for the compiled template</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>False</dev:defaultValue>
-        </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
           <maml:name>Confirm</maml:name>
           <maml:description>
@@ -152,16 +79,26 @@ Any error or warning from bicep will be written to the information stream. To sa
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-          <maml:name>OutputPath</maml:name>
+          <maml:name>GenerateAllParametersFile</maml:name>
           <maml:description>
-            <maml:para>{{ Fill OutputPath Description }}</maml:para>
+            <maml:para>Generate an ARM template parameter file with all parameters from the bicep file.</maml:para>
           </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
-            <maml:name>String</maml:name>
+            <maml:name>SwitchParameter</maml:name>
             <maml:uri />
           </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>GenerateRequiredParametersFile</maml:name>
+          <maml:description>
+            <maml:para>Generate an ARM template parameter file with the required parameters from the bicep file.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
       </command:syntaxItem>
       <command:syntaxItem>
@@ -284,6 +221,89 @@ Any error or warning from bicep will be written to the information stream. To sa
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
       </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Build-Bicep</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="2" aliases="none">
+          <maml:name>Path</maml:name>
+          <maml:description>
+            <maml:para>Specfies the path to the directory or file that should be compiled</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>$pwd.path</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>ExcludeFile</maml:name>
+          <maml:description>
+            <maml:para>Specifies a .bicep file to exclude from compilation</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+          <maml:name>Confirm</maml:name>
+          <maml:description>
+            <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+          <maml:name>WhatIf</maml:name>
+          <maml:description>
+            <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>OutputPath</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill OutputPath Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>GenerateAllParametersFile</maml:name>
+          <maml:description>
+            <maml:para>Generate an ARM template parameter file with all parameters from the bicep file.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>GenerateRequiredParametersFile</maml:name>
+          <maml:description>
+            <maml:para>Generate an ARM template parameter file with the required parameters from the bicep file.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
     </command:syntax>
     <command:parameters>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="2" aliases="none">
@@ -321,18 +341,6 @@ Any error or warning from bicep will be written to the information stream. To sa
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
-      </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-        <maml:name>GenerateParameterFile</maml:name>
-        <maml:description>
-          <maml:para>The -GenerateParameterFile parameter generates a ARM Template parameter file for the compiled template</maml:para>
-        </maml:description>
-        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-        <dev:type>
-          <maml:name>String</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>AsString</maml:name>
@@ -394,6 +402,30 @@ Any error or warning from bicep will be written to the information stream. To sa
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>GenerateAllParametersFile</maml:name>
+        <maml:description>
+          <maml:para>Generate an ARM template parameter file with all parameters from the bicep file.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>GenerateRequiredParametersFile</maml:name>
+        <maml:description>
+          <maml:para>Generate an ARM template parameter file with the required parameters from the bicep file.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
     </command:parameters>
     <command:inputTypes />
     <command:returnValues />
@@ -440,7 +472,7 @@ Any error or warning from bicep will be written to the information stream. To sa
       </command:example>
       <command:example>
         <maml:title>Example 6: Compile a .bicep files in the working directory and generate a parameter file with all parameters</maml:title>
-        <dev:code>Build-Bicep -Path '.\vnet.bicep' -GenerateParameterFile All</dev:code>
+        <dev:code>Build-Bicep -Path '.\vnet.bicep' -GenerateAllParametersFile</dev:code>
         <dev:remarks>
           <maml:para></maml:para>
         </dev:remarks>
@@ -1140,9 +1172,9 @@ Convert-JsonToBicep -String $json</dev:code>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-          <maml:name>Type</maml:name>
+          <maml:name>Parameters</maml:name>
           <maml:description>
-            <maml:para>{{ Fill Type Description }}</maml:para>
+            <maml:para>Specify which parameters should be exported to the parameter file.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -1203,9 +1235,9 @@ Convert-JsonToBicep -String $json</dev:code>
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-        <maml:name>Type</maml:name>
+        <maml:name>Parameters</maml:name>
         <maml:description>
-          <maml:para>{{ Fill Type Description }}</maml:para>
+          <maml:para>Specify which parameters should be exported to the parameter file.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -1249,8 +1281,8 @@ Convert-JsonToBicep -String $json</dev:code>
         </dev:remarks>
       </command:example>
       <command:example>
-        <maml:title>Example 2: Generate an ARM Template parameter file for a bicep file with only required parameters</maml:title>
-        <dev:code>New-BicepParameterFile -Path 'AzureFirewall.bicep' -Type Required</dev:code>
+        <maml:title>Example 2: Generate an ARM Template parameter file for a bicep file with all parameters from the bicep file</maml:title>
+        <dev:code>New-BicepParameterFile -Path 'AzureFirewall.bicep' -Parameters All</dev:code>
         <dev:remarks>
           <maml:para>Creates a parameter file called AzureFirewall.parameters.json in the same directory as the bicep file.</maml:para>
         </dev:remarks>


### PR DESCRIPTION
This PR partially closes #25. But I'm not sure if we need the `-Default` option mentioned in the issue or not. 

- Replaced the `-GenerateParameterFile` switch with two new switches in ´Build-Bicep`
  - `-GenerateAllParametersFile` generates a parameter file with all parameters in the bicep file
  - `-GenerateRequiredParametersFile` generates a parameter file with the required parameters only
  - Since we already have six parameter sets for `Build-Bicep` I've added a check if someone uses both switches at the same time and will then choose `All` and write a warning instead of adding another parameter set.

- Added the parameter `-Parameters` to `New-BicepParameterFile`, accepts inputs `All` or `Required
  - `All` generates a parameter file with all parameters in the bicep file
  - `Required` generates a parameter file with the required parameters only
  - If the parameter isn't provided it will default to `Required`

- Updated help files for both `Build-Bicep` and `New-BicepParameterFile`
- Updated external help file

How to use:

params.bicep
```bicep
param resourceName string
param rules object
param location string = resourceGroup().location
param accessTier string = 'SuperHot'
```

```powershell
#Generate parameter file during build with all parameters
Build-Bicep -Path params.bicep -GenerateAllParametersFile

#Generate parameter file during build with required parameters only
Build-Bicep -Path params.bicep -GenerateRequiredParametersFile

#Create parameter file with required parameters only
New-BicepParameterFile -Type params.bicep -Parameters Required
or
New-BicepParameterFile -Path params.bicep

#Create parameter file with all parameters
New-BicepParameterFile -Path params.bicep -Parameters All
```
 
