### PR TITLE
Updated to CreateWithAzTypes() method for AzResourceTypeProvider

### DIFF
--- a/Source/Private/ParseBicep.ps1
+++ b/Source/Private/ParseBicep.ps1
@@ -9,7 +9,7 @@ function ParseBicep {
         $FileResolver = [Bicep.Core.FileSystem.FileResolver]::new()
         $WorkSpace = [Bicep.Core.Workspaces.Workspace]::new()
         $PathHelper = [Bicep.Core.FileSystem.PathHelper]::FilePathToFileUrl($Path)
-        $ResourceTypeProvider = [Bicep.Core.TypeSystem.Az.AzResourceTypeProvider]::new()
+        $ResourceTypeProvider = [Bicep.Core.TypeSystem.Az.AzResourceTypeProvider]::CreateWithAzTypes()
         $SyntaxTreeGrouping = [Bicep.Core.Syntax.SyntaxTreeGroupingBuilder]::Build($FileResolver, $WorkSpace, $PathHelper)
         $Compilation = [Bicep.Core.Semantics.Compilation]::new($ResourceTypeProvider, $SyntaxTreeGrouping)
         $CompilationResults = $Compilation.GetAllDiagnosticsBySyntaxTree()

--- a/Source/Public/Convert-JsonToBicep.ps1
+++ b/Source/Public/Convert-JsonToBicep.ps1
@@ -15,7 +15,7 @@ function Convert-JsonToBicep {
 
     begin {
         $FileResolver = [Bicep.Core.FileSystem.FileResolver]::new()
-        $ResourceProvider = [Bicep.Core.TypeSystem.Az.AzResourceTypeProvider]::new()
+        $ResourceProvider = [Bicep.Core.TypeSystem.Az.AzResourceTypeProvider]::CreateWithAzTypes()
         $tempPath = [System.Io.Path]::GetTempPath()
     }
 

--- a/Source/Public/ConvertTo-Bicep.ps1
+++ b/Source/Public/ConvertTo-Bicep.ps1
@@ -18,7 +18,7 @@ If you would like to report any issues or inaccurate conversions, please see htt
         }
         
         $FileResolver = [Bicep.Core.FileSystem.FileResolver]::new()
-        $ResourceProvider = [Bicep.Core.TypeSystem.Az.AzResourceTypeProvider]::new()
+        $ResourceProvider = [Bicep.Core.TypeSystem.Az.AzResourceTypeProvider]::CreateWithAzTypes()
     }
 
     process {


### PR DESCRIPTION
This PR fixes an issue with the latest bicep assemblies `v0.3.539`. New methods have been added to `[Bicep.Core.TypeSystem.Az.AzResourceTypeProvider]` and we need to specify which one to use instead of using `::new()`. 

Updated the following functions with `[Bicep.Core.TypeSystem.Az.AzResourceTypeProvider]::CreateWithAzTypes()` instead of `[Bicep.Core.TypeSystem.Az.AzResourceTypeProvider]::new()`
- `ParseBicep.ps1`
- `Convert-JsonToBicep.ps1`
- `ConvertTo-Bicep.ps1`

Closes #147 