### PR TITLE
Fix ConvertToHashTable empty or single value arrays

### DIFF
--- a/Source/Private/ConvertToHashtable.ps1
+++ b/Source/Private/ConvertToHashtable.ps1
@@ -7,16 +7,16 @@ function ConvertToHashtable {
         $Ordered
     )
     process {
-
+ 
         # If InputObject is string or valuetype, don't recurse, just return the value.
-        if(
+        if (
             $null -eq $InputObject -or 
             $InputObject.GetType().FullName -eq 'System.String' -or 
             $InputObject.GetType().IsValueType
         ) {
             return $InputObject
         }
-
+ 
         # Else,  create a hashtable and loop over properties.
         if ($Ordered.IsPresent) {
             $HashTable = [ordered]@{}
@@ -32,8 +32,16 @@ function ConvertToHashtable {
             ) {
                 $HashTable.Add($Prop.Name, $Prop.Value)
             }
-            else{
-                $Value = $Prop.Value | ConvertToHashtable -Ordered:$Ordered
+            else {
+                if ($Prop.TypeNameOfValue -eq 'System.Object[]' -and !$Prop.Value) {
+                    $Value = @()
+                }
+                elseif ($Prop.TypeNameOfValue -eq 'System.Object[]' -and $Prop.Value) {
+                    $Value = @($Prop.Value)
+                }
+                else {
+                    $Value = $Prop.Value | ConvertToHashtable -Ordered:$Ordered
+                }
                 $HashTable.Add($Prop.Name, $Value)
             }
         }


### PR DESCRIPTION
Fixes #154 

Noticed that `Convert-JsonToBicep` returns empty arrays as `null` and single value arrays as `string`. Updated `ConvertToHashtable.ps1` to handle these cases.

To test:
```powershell
$json = @"
[
    {
        "properties": {
            "NSGName": "subnet2-nsg",
            "SubnetName": "subnet2",
            "RouteName": "",
            "disableBgpRoutePropagation": true,
            "routes": []
        }
    },
    {
        "properties": {
            "NSGName": "subnet3-nsg",
            "SubnetName": "subnet3",
            "RouteName": "",
            "disableBgpRoutePropagation": false,
            "routes": [
                "steffe"
            ]
        }
    },
    {
        "properties": {
            "NSGName": "subnet4-nsg",
            "SubnetName": "subnet3",
            "RouteName": "mjau",
            "disableBgpRoutePropagation": false,
            "routes": [
                "steffe",
                "Bosse"
            ]
        }
    },
    {
        "properties": {
            "NSGName": "subnet4-nsg",
            "SubnetName": "subnet3",
            "RouteName": "mjau",
            "disableBgpRoutePropagation": false,
            "routes": [
                {
                "steffe": "hej",
                "Bosse": "kalle"
                },
                {
                "steffe": 1,
                "Bosse": true
                }
            ]
        }
    }
]
"@
Convert-JsonToBicep -String $json
```