### PR TITLE
Removed required version from Pester

### DIFF
--- a/.github/workflows/RunTests.yaml
+++ b/.github/workflows/RunTests.yaml
@@ -20,7 +20,7 @@ jobs:
       shell: pwsh
       run: ./scripts/downloadDependencies.ps1
     - name: Import required modules
-      run: Install-Module -Name Pester -RequiredVersion 5.1.1 -Force
+      run: Install-Module -Name Pester -Force
       shell: pwsh
     - name: Run Pester tests and build module
       run: | 


### PR DESCRIPTION
Removed required version from Pester, possible fix: https://github.com/pester/Pester/pull/1941