### PR TITLE
Update-BicepParameterFile fixes

### DIFF
--- a/Source/Public/New-BicepParameterFile.ps1
+++ b/Source/Public/New-BicepParameterFile.ps1
@@ -34,7 +34,7 @@ function New-BicepParameterFile {
         $File = Get-Item -Path $Path
         
         if ($File) {
-            $ARMTemplate = ParseBicep -Path $File.FullName
+            $ARMTemplate = ParseBicep -Path $File.FullName -IgnoreDiagnostics
 
             if($PSBoundParameters.ContainsKey('OutputDirectory')) {
                 $OutputFilePath = Join-Path -Path $OutputDirectory -ChildPath ('{0}.parameters.json' -f $File.BaseName)

--- a/Source/Public/Update-BicepParameterFile.ps1
+++ b/Source/Public/Update-BicepParameterFile.ps1
@@ -80,14 +80,14 @@ function Update-BicepParameterFile {
         }
         
         
-        # Generate a new temporary Bicep Parameter File if -Parameters is set to Required
+        # Generate a new temporary Bicep Parameter File if -Parameters parameter is set to Required
         if ($Parameters -eq 'Required') {
             $BicepFileName = (Get-Item -Path $BicepFilePath).BaseName
             New-BicepParameterFile -Path $BicepFilePath -OutputDirectory $tempPath -Parameters $Parameters
         }
         $NewParametersFilePath = $tempPath + "$BicepFileName.parameters.json"
         
-        # Convert the new paramter file to an ordered hashtable
+        # Convert the new parameter file to an ordered hashtable
         try {
             $NewParametersFile = Get-Content -Path $NewParametersFilePath -ErrorAction Stop | ConvertFrom-Json -Depth 100 | ConvertToHashtable -Ordered
         }
@@ -96,7 +96,6 @@ function Update-BicepParameterFile {
             Break
         }
         
-        # Create an array with the new parameters
         $ParameterArray = @()
         $NewParametersFile.parameters.Keys.ForEach( { $ParameterArray += $PSItem })
         

--- a/Source/Public/Update-BicepParameterFile.ps1
+++ b/Source/Public/Update-BicepParameterFile.ps1
@@ -51,7 +51,7 @@ function Update-BicepParameterFile {
             $BicepFilePath = $BicepFile
         }
         
-        # Import the old paramter file and convert it to an ordered hashtable
+        # Import the old parameter file and convert it to an ordered hashtable
         $oldParametersFile = Get-Content -Path $Path | ConvertFrom-Json -Depth 100 | ConvertToHashtable -Ordered
 
         # Generate a temporary Bicep Parameter File with all parameters

--- a/Source/Public/Update-BicepParameterFile.ps1
+++ b/Source/Public/Update-BicepParameterFile.ps1
@@ -71,10 +71,10 @@ function Update-BicepParameterFile {
 
         # Remove any deleted parameters from old parameter file
         $oldParameterArray = @()
-        $oldParametersFile.parameters.Keys.ForEach( { $oldParameterArray += $PSItem })
+        $oldParametersFile.parameters.Keys.ForEach( { $oldParameterArray += $_ })
         
         foreach ($item in $oldParameterArray) {
-            if (!$allParametersFile.parameters.Contains($item)) {
+            if (-not $allParametersFile.parameters.Contains($item)) {
                 $oldParametersFile.parameters.Remove($item)
             }
         }
@@ -97,11 +97,11 @@ function Update-BicepParameterFile {
         }
         
         $ParameterArray = @()
-        $NewParametersFile.parameters.Keys.ForEach( { $ParameterArray += $PSItem })
+        $NewParametersFile.parameters.Keys.ForEach( { $ParameterArray += $_ })
         
         # Iterate over the new parameters and add any missing to the old parameters array
         foreach ($item in $ParameterArray) {
-            if (!$oldParametersFile.parameters.Contains($item)) {
+            if (-not $oldParametersFile.parameters.Contains($item)) {
                 $oldParametersFile.parameters[$item] = @{                                
                     value = $NewParametersFile.parameters.$item.value
                 }

--- a/Source/Public/Update-BicepParameterFile.ps1
+++ b/Source/Public/Update-BicepParameterFile.ps1
@@ -54,7 +54,7 @@ function Update-BicepParameterFile {
         # Import the old paramter file and convert it to an ordered hashtable
         $oldParametersFile = Get-Content -Path $Path | ConvertFrom-Json -Depth 100 | ConvertToHashtable -Ordered
 
-        # Generate a temporary Bicep Parameter File with all paramters
+        # Generate a temporary Bicep Parameter File with all parameters
         $BicepFileName = (Get-Item -Path $BicepFilePath).BaseName
         New-BicepParameterFile -Path $BicepFilePath -OutputDirectory $tempPath -Parameters All
 
@@ -99,7 +99,7 @@ function Update-BicepParameterFile {
         $ParameterArray = @()
         $NewParametersFile.parameters.Keys.ForEach( { $ParameterArray += $PSItem })
         
-        # Iterate over the new paramters and add any missing to the old parameters array
+        # Iterate over the new parameters and add any missing to the old parameters array
         foreach ($item in $ParameterArray) {
             if (!$oldParametersFile.parameters.Contains($item)) {
                 $oldParametersFile.parameters[$item] = @{                                

--- a/Source/Public/Update-BicepParameterFile.ps1
+++ b/Source/Public/Update-BicepParameterFile.ps1
@@ -34,9 +34,10 @@ function Update-BicepParameterFile {
         
         $FileName = $ParamFile.BaseName.Replace('.parameters', '')
         
+        # Try to find a matching Bicep template for the provided parameter file based on its file name
         if (-not $PSBoundParameters.ContainsKey('BicepFile')) {
             $BicepFilePath = (Get-ChildItem $ParamFile.DirectoryName -Filter *.bicep | Where-Object { $_.BaseName -eq $FileName }).FullName
-
+            
             if (-not $BicepFilePath) {
                 Write-Error "Cant find BicepFile Named $FileName in directory: $($ParamFile.DirectoryName)"
                 Break
@@ -49,12 +50,44 @@ function Update-BicepParameterFile {
             }
             $BicepFilePath = $BicepFile
         }
+        
+        # Import the old paramter file and convert it to an ordered hashtable
+        $oldParametersFile = Get-Content -Path $Path | ConvertFrom-Json -Depth 100 | ConvertToHashtable -Ordered
 
+        # Generate a temporary Bicep Parameter File with all paramters
         $BicepFileName = (Get-Item -Path $BicepFilePath).BaseName
-        New-BicepParameterFile -Path $BicepFilePath -OutputDirectory $tempPath -Parameters $Parameters
+        New-BicepParameterFile -Path $BicepFilePath -OutputDirectory $tempPath -Parameters All
 
-        $NewParametersFilePath = $tempPath+"$BicepFileName.parameters.json"
+        $allParametersFilePath = $tempPath + "$($BicepFileName).parameters.json"
 
+        # Convert the all parameters file to an ordered hashtable
+        try {
+            $allParametersFile = Get-Content -Path $allParametersFilePath -ErrorAction Stop | ConvertFrom-Json -Depth 100 | ConvertToHashtable -Ordered
+        }
+        catch {
+            Write-Error "Failed to create Bicep ParameterObject."
+            Break
+        }        
+
+        # Remove any deleted parameters from old parameter file
+        $oldParameterArray = @()
+        $oldParametersFile.parameters.Keys.ForEach( { $oldParameterArray += $PSItem })
+        
+        foreach ($item in $oldParameterArray) {
+            if (!$allParametersFile.parameters.Contains($item)) {
+                $oldParametersFile.parameters.Remove($item)
+            }
+        }
+        
+        
+        # Generate a new temporary Bicep Parameter File if -Parameters is set to Required
+        if ($Parameters -eq 'Required') {
+            $BicepFileName = (Get-Item -Path $BicepFilePath).BaseName
+            New-BicepParameterFile -Path $BicepFilePath -OutputDirectory $tempPath -Parameters $Parameters
+        }
+        $NewParametersFilePath = $tempPath + "$BicepFileName.parameters.json"
+        
+        # Convert the new paramter file to an ordered hashtable
         try {
             $NewParametersFile = Get-Content -Path $NewParametersFilePath -ErrorAction Stop | ConvertFrom-Json -Depth 100 | ConvertToHashtable -Ordered
         }
@@ -63,17 +96,19 @@ function Update-BicepParameterFile {
             Break
         }
         
-        $OldParametersFile = Get-Content -Path $Path | ConvertFrom-Json -Depth 100 | ConvertToHashtable -Ordered
-
+        # Create an array with the new parameters
         $ParameterArray = @()
-        $NewParametersFile.parameters.Keys.ForEach({ $ParameterArray += $PSItem })
+        $NewParametersFile.parameters.Keys.ForEach( { $ParameterArray += $PSItem })
         
+        # Iterate over the new paramters and add any missing to the old parameters array
         foreach ($item in $ParameterArray) {
-            if ($OldParametersFile.parameters.Contains($item)) {
-                $NewParametersFile.parameters[$item] = $OldParametersFile.parameters[$item]
+            if (!$oldParametersFile.parameters.Contains($item)) {
+                $oldParametersFile.parameters[$item] = @{                                
+                    value = $NewParametersFile.parameters.$item.value
+                }
             }
         }
-        $NewParametersFile | ConvertTo-Json -Depth 100 | Out-File -Path $Path -Force
+        $oldParametersFile | ConvertTo-Json -Depth 100 | Out-File -Path $Path -Force
         
     }
     end {


### PR DESCRIPTION
Fixes #191. And closes #159.

Also added `-IgnoreDiagnostics` switch in New-BicepParameterFile. No need to output build warnings when working with parameter files.